### PR TITLE
Add 6, 16 and 32 speed options for fans

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# *** I forked the original code to add support for 6, 16 and 32 speed Fanimation fans. ***
-
-
 # FanimationHA-AC-BT
 
 [Home Assistant](https://www.home-assistant.io/) HACS custom component for **local Bluetooth control** of Fanimation ceiling fans using the BTCR9 FanSync Bluetooth receiver. No cloud, no app dependency. Includes the fully reverse-engineered BLE protocol and diagnostic tools.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# *** I forked the original code to add support for 6, 16 and 32 speed Fanimation fans. ***
+
+
 # FanimationHA-AC-BT
 
 [Home Assistant](https://www.home-assistant.io/) HACS custom component for **local Bluetooth control** of Fanimation ceiling fans using the BTCR9 FanSync Bluetooth receiver. No cloud, no app dependency. Includes the fully reverse-engineered BLE protocol and diagnostic tools.

--- a/custom_components/fanimation/config_flow.py
+++ b/custom_components/fanimation/config_flow.py
@@ -26,6 +26,7 @@ from .const import (
     CONF_DEFAULT_BRIGHTNESS,
     CONF_DEFAULT_SPEED,
     CONF_NOTIFY_ON_DISCONNECT,
+    CONF_SPEED_COUNT,
     CONF_UNAVAILABLE_THRESHOLD,
     DEFAULT_BRIGHTNESS_LAST_USED,
     DEFAULT_NOTIFY_ON_DISCONNECT,
@@ -37,6 +38,7 @@ from .const import (
     DOMAIN,
     LOGGER,
     MAX_UNAVAILABLE_THRESHOLD,
+    SPEED_COUNT,
 )
 
 SERVICE_UUID = "0000e000-0000-1000-8000-00805f9b34fb"
@@ -76,7 +78,7 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
                 max_attempts=2,
             )
             try:
-                # Verify the expected service and characteristics exist
+				# Verify the expected service and characteristics exist
                 services = client.services
                 write_char = services.get_characteristic(CHAR_WRITE)
                 notify_char = services.get_characteristic(CHAR_NOTIFY)
@@ -132,6 +134,7 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
                 data={
                     CONF_MAC: self._mac,
                     CONF_NAME: name,
+                    CONF_SPEED_COUNT: user_input[CONF_SPEED_COUNT],
                 },
             )
 
@@ -144,6 +147,7 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_NAME, default=self._discovered_name): str,
+                    vol.Required(CONF_SPEED_COUNT, default=SPEED_COUNT): vol.In([3, 6]),
                 }
             ),
         )
@@ -160,7 +164,7 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(mac)
             self._abort_if_unique_id_configured()
 
-            # Test-before-configure: verify the device is reachable
+				# Test-before-configure: verify the device is reachable
             # and has the expected GATT characteristics
             if not await self._async_validate_device(mac):
                 errors["base"] = "cannot_connect"
@@ -170,6 +174,7 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
                     data={
                         CONF_MAC: mac,
                         CONF_NAME: name,
+                        CONF_SPEED_COUNT: user_input[CONF_SPEED_COUNT],
                     },
                 )
 
@@ -182,6 +187,7 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
                         vol.Match(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$"),
                     ),
                     vol.Required(CONF_NAME, default="Fanimation Fan"): str,
+                    vol.Required(CONF_SPEED_COUNT, default=SPEED_COUNT): vol.In([3, 6]),
                 }
             ),
             errors=errors,
@@ -194,7 +200,7 @@ class FanimationOptionsFlow(OptionsFlowWithConfigEntry):
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
-            # Flatten sections into a single options dict
+            # Flatten sections into a single options dict 
             flat = {}
             flat.update(user_input.get("defaults", {}))
             flat.update(user_input.get("connection", {}))

--- a/custom_components/fanimation/config_flow.py
+++ b/custom_components/fanimation/config_flow.py
@@ -147,7 +147,7 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_NAME, default=self._discovered_name): str,
-                    vol.Required(CONF_SPEED_COUNT, default=SPEED_COUNT): vol.In([3, 6]),
+                    vol.Required(CONF_SPEED_COUNT, default=SPEED_COUNT): vol.In([3, 6, 16, 32]),
                 }
             ),
         )

--- a/custom_components/fanimation/config_flow.py
+++ b/custom_components/fanimation/config_flow.py
@@ -182,12 +182,9 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_MAC): vol.All(
-                        str,
-                        vol.Match(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$"),
-                    ),
+                    vol.Required(CONF_MAC): vol.All(str),
                     vol.Required(CONF_NAME, default="Fanimation Fan"): str,
-                    vol.Required(CONF_SPEED_COUNT, default=SPEED_COUNT): vol.In([3, 6]),
+                    vol.Required(CONF_SPEED_COUNT, default=SPEED_COUNT): vol.In([3, 6, 16, 32]),
                 }
             ),
             errors=errors,

--- a/custom_components/fanimation/const.py
+++ b/custom_components/fanimation/const.py
@@ -53,6 +53,7 @@ CONF_DEFAULT_SPEED = "default_speed"
 CONF_DEFAULT_BRIGHTNESS = "default_brightness"
 CONF_NOTIFY_ON_DISCONNECT = "notify_on_disconnect"
 CONF_UNAVAILABLE_THRESHOLD = "unavailable_threshold"
+CONF_SPEED_COUNT = "speed_count"
 
 # Option defaults
 DEFAULT_SPEED_LAST_USED = "last_used"

--- a/custom_components/fanimation/fan.py
+++ b/custom_components/fanimation/fan.py
@@ -2,6 +2,131 @@
 
 from __future__ import annotations
 
+import math
+from typing import Any
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.percentage import (
+    percentage_to_ranged_value,
+    ranged_value_to_percentage,
+)
+
+from . import FanimationConfigEntry
+from .const import (
+    CONF_DEFAULT_SPEED,
+    CONF_SPEED_COUNT,
+    DEFAULT_SPEED_LAST_USED,
+    SPEED_COUNT,
+    SPEED_HIGH,
+    SPEED_LOW,
+    SPEED_MED,
+    SPEED_OFF,
+    SPEED_OPTION_MAP,
+)
+from .coordinator import FanimationCoordinator
+from .entity import FanimationEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: FanimationConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the fan entity."""
+    coordinator = entry.runtime_data
+    # Changed entry_id to full entry so we can access user data
+    async_add_entities([FanimationFan(coordinator, entry)])
+
+
+class FanimationFan(FanimationEntity, FanEntity):
+    """Fanimation ceiling fan entity."""
+
+    _attr_supported_features = FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+    _attr_name = None  # Primary entity — uses device name only
+
+    def __init__(
+        self,
+        coordinator: FanimationCoordinator,
+        entry: FanimationConfigEntry,
+    ) -> None:
+        """Initialize the fan entity."""
+        super().__init__(coordinator, entry.entry_id)
+        self._attr_unique_id = f"{coordinator.device.mac}_fan"
+        self._last_speed = SPEED_LOW  # default for turn_on without speed
+        # Fetch the speed count the user chose during setup
+        self._attr_speed_count = entry.data.get(CONF_SPEED_COUNT, SPEED_COUNT)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the fan is on."""
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.speed > SPEED_OFF
+
+    @property
+    def percentage(self) -> int | None:
+        """Return the current speed percentage."""
+        if self.coordinator.data is None:
+            return None
+        speed = self.coordinator.data.speed
+        if speed == SPEED_OFF:
+            return 0
+        # Dynamically calculate percentage based on max speeds
+        return ranged_value_to_percentage((1, self.speed_count), speed)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        attrs = super().extra_state_attributes
+        attrs["rf_remote_sync"] = "State is verified before every command — RF remote changes are always respected"
+        return attrs
+
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Turn on the fan."""
+        if percentage is not None:
+            await self.async_set_percentage(percentage)
+            return
+
+        # Check for user-configured fixed default speed
+        default_speed = DEFAULT_SPEED_LAST_USED
+        if self.coordinator.config_entry and self.coordinator.config_entry.options:
+            default_speed = self.coordinator.config_entry.options.get(CONF_DEFAULT_SPEED, DEFAULT_SPEED_LAST_USED)
+
+        if default_speed in SPEED_OPTION_MAP:
+            await self._async_set_speed(SPEED_OPTION_MAP[default_speed])
+        else:
+            # "last_used" or unrecognized — use last known speed
+            await self._async_set_speed(self._last_speed)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the fan."""
+        await self._async_set_speed(SPEED_OFF)
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set fan speed by percentage."""
+        if percentage == 0:
+            await self._async_set_speed(SPEED_OFF)
+        else:
+            # Map percentage (e.g. 65%) to an exact speed (e.g. 21) using math
+            speed = math.ceil(percentage_to_ranged_value((1, self.speed_count), percentage))
+            await self._async_set_speed(speed)
+
+    async def _async_set_speed(self, speed: int) -> None:
+        """Set fan speed and trigger fast poll."""
+        if speed > SPEED_OFF:
+            self._last_speed = speed
+        await self.coordinator.device.async_set_state(speed=speed)
+        await self.coordinator.async_start_fast_poll()"""Fan entity for Fanimation BLE integration."""
+
+from __future__ import annotations
+
 from typing import Any
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature

--- a/custom_components/fanimation/strings.json
+++ b/custom_components/fanimation/strings.json
@@ -5,7 +5,8 @@
         "title": "Fanimation Ceiling Fan Detected",
         "description": "Found: {name} ({mac})\n\nThis fan can also be controlled by its RF remote. All commands from Home Assistant will read the current fan state first, so remote changes are never overwritten.",
         "data": {
-          "name": "Friendly name"
+          "name": "Friendly name",
+          "speed_count": "Number of fan speeds"
         }
       },
       "user": {
@@ -13,7 +14,8 @@
         "description": "Enter the MAC address of your fan. You can find it using a BLE scanner app \u2014 look for a device named CeilingFan.",
         "data": {
           "mac": "MAC address",
-          "name": "Friendly name"
+          "name": "Friendly name",
+          "speed_count": "Number of fan speeds"
         }
       }
     },

--- a/custom_components/fanimation/translations/en.json
+++ b/custom_components/fanimation/translations/en.json
@@ -5,7 +5,8 @@
         "title": "Fanimation Ceiling Fan Detected",
         "description": "Found: {name} ({mac})\n\nThis fan can also be controlled by its RF remote. All commands from Home Assistant will read the current fan state first, so remote changes are never overwritten.",
         "data": {
-          "name": "Friendly name"
+          "name": "Friendly name",
+          "speed_count": "Number of fan speeds"
         }
       },
       "user": {
@@ -13,7 +14,8 @@
         "description": "Enter the MAC address of your fan. You can find it using a BLE scanner app \u2014 look for a device named CeilingFan.",
         "data": {
           "mac": "MAC address",
-          "name": "Friendly name"
+          "name": "Friendly name",
+          "speed_count": "Number of fan speeds"
         }
       }
     },


### PR DESCRIPTION
This PR updates the Fanimation BLE integration to dynamically support fans with different speed counts (3, 6, 16, or 32 speeds), accommodating both standard AC and modern DC motor models.
What changed:

    const.py: 
      - Added CONF_SPEED_COUNT to standardize the storage key for the user's selected number of fan speeds.

    config_flow.py: 
      - Updated both the Bluetooth discovery and manual setup schemas to include a dropdown allowing users to select their fan's maximum speed count (vol.In([3, 6, 16, 32])). This selection is saved directly to the config entry data.

    strings.json & translations/en.json: 
      - Added UI translation strings for the new speed_count configuration field.

    fan.py: 
      * Refactored speed calculations to use Home Assistant's built-in percentage_to_ranged_value and ranged_value_to_percentage math utilities.

      - Removed the hardcoded ORDERED_NAMED_FAN_SPEEDS list.

      - The fan entity now dynamically calculates percentage steps based on the CONF_SPEED_COUNT saved during setup, natively translating UI slider percentages into the correct exact speed commands for the hardware.