### PR TITLE
Per-fan configurable speed count — DC fan support (closes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The BTCR9 BLE protocol has been fully reverse-engineered and verified against re
 
 | Feature | Range | Status |
 |---------|-------|--------|
-| Fan speed | Off / Low / Medium / High | Verified |
+| Fan speed | Off + 1-N (N is configurable per fan, default 3, max 99) | Verified on 3-speed AC; 6/32-speed DC support added in 1.2.0 (community-tested) |
 | Fan direction | Forward / Reverse | Not supported on AC motors |
 | Downlight brightness | 0-100% | Verified |
 | Sleep timer | 0-360 minutes | Verified |
@@ -40,12 +40,13 @@ Three entities per fan, grouped under one device:
 
 | Entity | Type | Controls |
 |--------|------|----------|
-| Fan | `fan` | Speed (off/low/med/high) |
+| Fan | `fan` | Speed slider with N discrete steps (N is your fan's speed count) |
 | Downlight | `light` | On/off, brightness (0-100%) |
 | Sleep Timer | `number` | 0-360 minutes (turns off fan + light on expiry) |
 
 Per-fan options are configurable via **Settings → Devices → Configure** ([screenshot](docs/screenshots/options-flow.png)):
-- **Default turn-on speed** — Last used, Low, Medium, or High
+- **Number of fan speeds** — pick a common value (1, 3, 6, 32) or type a custom number. Low/Medium/High and the slider scale automatically.
+- **Default turn-on speed** — Last used, Low, Medium, or High (Low/Medium/High map proportionally to your fan's speed count)
 - **Default light brightness** — 0 = last used, 1-100 = fixed level
 - **Disconnect notification** — persistent alert on first BLE failure
 - **Unavailable threshold** — how many poll failures before entities go grey
@@ -94,7 +95,14 @@ Find your fan's MAC address using any BLE scanner app (nRF Connect, LightBlue) �
 - **BLE receiver**: Fanimation BTCR9 FanSync Bluetooth Receiver
 - **Physical remote**: Fanimation BTT9 (3 speeds, downlight, no reverse)
 - **Smartphone app**: FanSync (Android / iOS)
-- **Motor type**: AC (3-speed capacitor-switched)
+- **Motor type**: AC (3-speed capacitor-switched) — fully tested
+
+### DC motor fans (community-tested in 1.2.0)
+
+DC fan models with the FanSync Bluetooth receiver expose more discrete speeds. Set **Number of fan speeds** to match your fan during setup (or change it later in options). Reported working:
+
+- **Fanimation Odyn 84"** with TR305 FanSync remote — 32 speeds
+- Other DC models commonly use 6 or 32 speeds — pick the matching value or type a custom number (1-99)
 
 Other Fanimation FanSync Bluetooth models likely share the same protocol but have not been tested.
 

--- a/custom_components/fanimation/config_flow.py
+++ b/custom_components/fanimation/config_flow.py
@@ -26,9 +26,11 @@ from .const import (
     CONF_DEFAULT_BRIGHTNESS,
     CONF_DEFAULT_SPEED,
     CONF_NOTIFY_ON_DISCONNECT,
+    CONF_SPEED_COUNT,
     CONF_UNAVAILABLE_THRESHOLD,
     DEFAULT_BRIGHTNESS_LAST_USED,
     DEFAULT_NOTIFY_ON_DISCONNECT,
+    DEFAULT_SPEED_COUNT,
     DEFAULT_SPEED_HIGH,
     DEFAULT_SPEED_LAST_USED,
     DEFAULT_SPEED_LOW,
@@ -36,10 +38,36 @@ from .const import (
     DEFAULT_UNAVAILABLE_THRESHOLD,
     DOMAIN,
     LOGGER,
+    MAX_SPEED_COUNT,
     MAX_UNAVAILABLE_THRESHOLD,
+    MIN_SPEED_COUNT,
+    SPEED_COUNT_COMMON,
 )
 
 SERVICE_UUID = "0000e000-0000-1000-8000-00805f9b34fb"
+
+
+def _speed_count_field() -> vol.All:
+    """Voluptuous validator for the speed-count form field.
+
+    Renders as a dropdown of common values (1, 3, 6, 32) with ``custom_value=True``
+    so users with unusual hardware can type any integer in [MIN, MAX]. Selector
+    returns a string, so we coerce to int and range-check before persisting.
+
+    Callers must pass form ``default`` values as ``str`` (e.g. ``str(DEFAULT_SPEED_COUNT)``)
+    because the underlying SelectSelector compares defaults against its string options.
+    """
+    return vol.All(
+        SelectSelector(
+            SelectSelectorConfig(
+                options=SPEED_COUNT_COMMON,
+                custom_value=True,
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        ),
+        vol.Coerce(int),
+        vol.Range(min=MIN_SPEED_COUNT, max=MAX_SPEED_COUNT),
+    )
 
 
 class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -132,6 +160,7 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
                 data={
                     CONF_MAC: self._mac,
                     CONF_NAME: name,
+                    CONF_SPEED_COUNT: user_input[CONF_SPEED_COUNT],
                 },
             )
 
@@ -144,6 +173,7 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_NAME, default=self._discovered_name): str,
+                    vol.Required(CONF_SPEED_COUNT, default=str(DEFAULT_SPEED_COUNT)): _speed_count_field(),
                 }
             ),
         )
@@ -170,6 +200,7 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
                     data={
                         CONF_MAC: mac,
                         CONF_NAME: name,
+                        CONF_SPEED_COUNT: user_input[CONF_SPEED_COUNT],
                     },
                 )
 
@@ -182,6 +213,7 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
                         vol.Match(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$"),
                     ),
                     vol.Required(CONF_NAME, default="Fanimation Fan"): str,
+                    vol.Required(CONF_SPEED_COUNT, default=str(DEFAULT_SPEED_COUNT)): _speed_count_field(),
                 }
             ),
             errors=errors,
@@ -223,8 +255,16 @@ class FanimationOptionsFlow(OptionsFlowWithConfigEntry):
 
     def _defaults_section_schema(self) -> vol.Schema:
         """Build schema for fan & light defaults section."""
+        current_speed_count = self.options.get(
+            CONF_SPEED_COUNT,
+            self.config_entry.data.get(CONF_SPEED_COUNT, DEFAULT_SPEED_COUNT),
+        )
         return vol.Schema(
             {
+                vol.Required(
+                    CONF_SPEED_COUNT,
+                    default=str(current_speed_count),
+                ): _speed_count_field(),
                 vol.Required(
                     CONF_DEFAULT_SPEED,
                     default=self.options.get(CONF_DEFAULT_SPEED, DEFAULT_SPEED_LAST_USED),

--- a/custom_components/fanimation/const.py
+++ b/custom_components/fanimation/const.py
@@ -28,12 +28,18 @@ CMD_GET_STATUS = 0x30
 CMD_SET_STATE = 0x31
 CMD_STATUS_RESPONSE = 0x32
 
-# Fan speed mapping (AC motor: 3 speeds only)
+# Fan speed protocol values
 SPEED_OFF = 0
 SPEED_LOW = 1
 SPEED_MED = 2
 SPEED_HIGH = 3
-SPEED_COUNT = 3
+
+# Speed count is per-fan and user-configurable (AC fans typically 3, DC fans 6/32).
+# Common values surfaced as dropdown options; users can type any int in [MIN, MAX].
+DEFAULT_SPEED_COUNT = 3
+MIN_SPEED_COUNT = 1
+MAX_SPEED_COUNT = 99
+SPEED_COUNT_COMMON: list[str] = ["1", "3", "6", "32"]
 
 # Downlight
 DOWNLIGHT_MIN = 0
@@ -53,6 +59,7 @@ CONF_DEFAULT_SPEED = "default_speed"
 CONF_DEFAULT_BRIGHTNESS = "default_brightness"
 CONF_NOTIFY_ON_DISCONNECT = "notify_on_disconnect"
 CONF_UNAVAILABLE_THRESHOLD = "unavailable_threshold"
+CONF_SPEED_COUNT = "speed_count"
 
 # Option defaults
 DEFAULT_SPEED_LAST_USED = "last_used"
@@ -64,9 +71,18 @@ DEFAULT_NOTIFY_ON_DISCONNECT = True
 DEFAULT_UNAVAILABLE_THRESHOLD = 12
 MAX_UNAVAILABLE_THRESHOLD = 2016  # ~1 week at 300s polling
 
-# Speed option → protocol speed mapping
-SPEED_OPTION_MAP: dict[str, int] = {
-    DEFAULT_SPEED_LOW: SPEED_LOW,
-    DEFAULT_SPEED_MEDIUM: SPEED_MED,
-    DEFAULT_SPEED_HIGH: SPEED_HIGH,
-}
+
+def speed_for_preset(preset: str, count: int) -> int | None:
+    """Map a low/medium/high preset to a concrete speed for a fan with N speeds.
+
+    For N=3 returns the original (1, 2, 3). For larger N, scales proportionally:
+    e.g. N=32 → low=11, medium=21, high=32. Returns None for unrecognized presets
+    (e.g. "last_used"), letting the caller fall back to last-known behaviour.
+    """
+    if preset == DEFAULT_SPEED_LOW:
+        return max(1, round(count / 3))
+    if preset == DEFAULT_SPEED_MEDIUM:
+        return max(1, round(2 * count / 3))
+    if preset == DEFAULT_SPEED_HIGH:
+        return count
+    return None

--- a/custom_components/fanimation/fan.py
+++ b/custom_components/fanimation/fan.py
@@ -2,31 +2,29 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.percentage import (
-    ordered_list_item_to_percentage,
-    percentage_to_ordered_list_item,
+    percentage_to_ranged_value,
+    ranged_value_to_percentage,
 )
 
 from . import FanimationConfigEntry
 from .const import (
     CONF_DEFAULT_SPEED,
+    CONF_SPEED_COUNT,
+    DEFAULT_SPEED_COUNT,
     DEFAULT_SPEED_LAST_USED,
-    SPEED_COUNT,
-    SPEED_HIGH,
     SPEED_LOW,
-    SPEED_MED,
     SPEED_OFF,
-    SPEED_OPTION_MAP,
+    speed_for_preset,
 )
 from .coordinator import FanimationCoordinator
 from .entity import FanimationEntity
-
-ORDERED_NAMED_FAN_SPEEDS = [SPEED_LOW, SPEED_MED, SPEED_HIGH]
 
 
 async def async_setup_entry(
@@ -36,24 +34,29 @@ async def async_setup_entry(
 ) -> None:
     """Set up the fan entity."""
     coordinator = entry.runtime_data
-    async_add_entities([FanimationFan(coordinator, entry.entry_id)])
+    async_add_entities([FanimationFan(coordinator, entry)])
 
 
 class FanimationFan(FanimationEntity, FanEntity):
     """Fanimation ceiling fan entity."""
 
-    _attr_speed_count = SPEED_COUNT
     _attr_supported_features = FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
     _attr_name = None  # Primary entity — uses device name only
 
     def __init__(
         self,
         coordinator: FanimationCoordinator,
-        entry_id: str,
+        entry: FanimationConfigEntry,
     ) -> None:
         """Initialize the fan entity."""
-        super().__init__(coordinator, entry_id)
+        super().__init__(coordinator, entry.entry_id)
         self._attr_unique_id = f"{coordinator.device.mac}_fan"
+        # Speed count: options-flow value wins, then install-time data, then default.
+        self._speed_count = entry.options.get(
+            CONF_SPEED_COUNT,
+            entry.data.get(CONF_SPEED_COUNT, DEFAULT_SPEED_COUNT),
+        )
+        self._attr_speed_count = self._speed_count
         self._last_speed = SPEED_LOW  # default for turn_on without speed
 
     @property
@@ -65,13 +68,21 @@ class FanimationFan(FanimationEntity, FanEntity):
 
     @property
     def percentage(self) -> int | None:
-        """Return the current speed percentage."""
+        """Return the current speed percentage.
+
+        Hardware speeds outside ``[1, speed_count]`` are clamped to the configured
+        max so a misconfigured speed_count never crashes the entity (Issue #1).
+        """
         if self.coordinator.data is None:
             return None
         speed = self.coordinator.data.speed
         if speed == SPEED_OFF:
             return 0
-        return ordered_list_item_to_percentage(ORDERED_NAMED_FAN_SPEEDS, speed)
+        # Clamp incoming speed: an out-of-range value (e.g. 5 reported by a
+        # 32-speed fan when the user has speed_count=3 misconfigured) would
+        # otherwise extrapolate above 100% and break the slider UI.
+        clamped = max(1, min(self._speed_count, speed))
+        return ranged_value_to_percentage((1, self._speed_count), clamped)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -96,8 +107,9 @@ class FanimationFan(FanimationEntity, FanEntity):
         if self.coordinator.config_entry and self.coordinator.config_entry.options:
             default_speed = self.coordinator.config_entry.options.get(CONF_DEFAULT_SPEED, DEFAULT_SPEED_LAST_USED)
 
-        if default_speed in SPEED_OPTION_MAP:
-            await self._async_set_speed(SPEED_OPTION_MAP[default_speed])
+        preset_speed = speed_for_preset(default_speed, self._speed_count)
+        if preset_speed is not None:
+            await self._async_set_speed(preset_speed)
         else:
             # "last_used" or unrecognized — use last known speed
             await self._async_set_speed(self._last_speed)
@@ -110,9 +122,12 @@ class FanimationFan(FanimationEntity, FanEntity):
         """Set fan speed by percentage."""
         if percentage == 0:
             await self._async_set_speed(SPEED_OFF)
-        else:
-            speed = percentage_to_ordered_list_item(ORDERED_NAMED_FAN_SPEEDS, percentage)
-            await self._async_set_speed(speed)
+            return
+        # ceil keeps small percentages > 0 from rounding to off; clamp guards
+        # against rounding past max at exactly 100%.
+        raw = math.ceil(percentage_to_ranged_value((1, self._speed_count), percentage))
+        speed = max(1, min(self._speed_count, raw))
+        await self._async_set_speed(speed)
 
     async def _async_set_speed(self, speed: int) -> None:
         """Set fan speed and trigger fast poll."""

--- a/custom_components/fanimation/fan.py
+++ b/custom_components/fanimation/fan.py
@@ -130,8 +130,16 @@ class FanimationFan(FanimationEntity, FanEntity):
         await self._async_set_speed(speed)
 
     async def _async_set_speed(self, speed: int) -> None:
-        """Set fan speed and trigger fast poll."""
-        if speed > SPEED_OFF:
-            self._last_speed = speed
-        await self.coordinator.device.async_set_state(speed=speed)
+        """Set fan speed and trigger fast poll.
+
+        ``_last_speed`` is updated from the *verified* response, not the requested
+        value. If speed_count is misconfigured (e.g. set to 6 on a 3-speed fan),
+        the firmware silently turns off when it receives a SPEED byte it can't
+        honour. Pinning ``_last_speed`` to the rejected value would put
+        ``async_turn_on`` (with default = "Last Used") into a stuck-off loop:
+        every toggle resends the bad value and the fan stays off.
+        """
+        state = await self.coordinator.device.async_set_state(speed=speed)
+        if state is not None and state.speed > SPEED_OFF:
+            self._last_speed = state.speed
         await self.coordinator.async_start_fast_poll()

--- a/custom_components/fanimation/manifest.json
+++ b/custom_components/fanimation/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/sumgup0/FanimationHA-AC-BT/issues",
   "loggers": ["custom_components.fanimation"],
   "requirements": ["bleak-retry-connector>=4.0.0"],
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/custom_components/fanimation/strings.json
+++ b/custom_components/fanimation/strings.json
@@ -5,7 +5,11 @@
         "title": "Fanimation Ceiling Fan Detected",
         "description": "Found: {name} ({mac})\n\nThis fan can also be controlled by its RF remote. All commands from Home Assistant will read the current fan state first, so remote changes are never overwritten.",
         "data": {
-          "name": "Friendly name"
+          "name": "Friendly name",
+          "speed_count": "Number of fan speeds"
+        },
+        "data_description": {
+          "speed_count": "Pick or type the number of speeds your fan supports. AC fans are usually 3; DC fans are commonly 6 or 32. You can change this later in the integration's options."
         }
       },
       "user": {
@@ -13,7 +17,11 @@
         "description": "Enter the MAC address of your fan. You can find it using a BLE scanner app \u2014 look for a device named CeilingFan.",
         "data": {
           "mac": "MAC address",
-          "name": "Friendly name"
+          "name": "Friendly name",
+          "speed_count": "Number of fan speeds"
+        },
+        "data_description": {
+          "speed_count": "Pick or type the number of speeds your fan supports. AC fans are usually 3; DC fans are commonly 6 or 32. You can change this later in the integration's options."
         }
       }
     },
@@ -35,11 +43,13 @@
             "name": "Fan & light defaults",
             "description": "These settings control what happens when you turn on the fan or light without specifying a speed or brightness (e.g., tapping a toggle in your dashboard).",
             "data": {
+              "speed_count": "Number of fan speeds",
               "default_speed": "Default turn-on speed",
               "default_brightness": "Default light brightness"
             },
             "data_description": {
-              "default_speed": "The fan speed used when you turn the fan on without choosing a specific speed.",
+              "speed_count": "How many discrete speeds your fan supports. AC fans are usually 3; DC fans are commonly 6 or 32. Pick a common value or type a custom number.",
+              "default_speed": "The fan speed used when you turn the fan on without choosing a specific speed. Low/Medium/High scale automatically based on the speed count above.",
               "default_brightness": "The brightness used when you turn the light on without choosing a specific level. Set to 0 to use the last brightness."
             }
           },

--- a/custom_components/fanimation/translations/en.json
+++ b/custom_components/fanimation/translations/en.json
@@ -5,7 +5,11 @@
         "title": "Fanimation Ceiling Fan Detected",
         "description": "Found: {name} ({mac})\n\nThis fan can also be controlled by its RF remote. All commands from Home Assistant will read the current fan state first, so remote changes are never overwritten.",
         "data": {
-          "name": "Friendly name"
+          "name": "Friendly name",
+          "speed_count": "Number of fan speeds"
+        },
+        "data_description": {
+          "speed_count": "Pick or type the number of speeds your fan supports. AC fans are usually 3; DC fans are commonly 6 or 32. You can change this later in the integration's options."
         }
       },
       "user": {
@@ -13,7 +17,11 @@
         "description": "Enter the MAC address of your fan. You can find it using a BLE scanner app \u2014 look for a device named CeilingFan.",
         "data": {
           "mac": "MAC address",
-          "name": "Friendly name"
+          "name": "Friendly name",
+          "speed_count": "Number of fan speeds"
+        },
+        "data_description": {
+          "speed_count": "Pick or type the number of speeds your fan supports. AC fans are usually 3; DC fans are commonly 6 or 32. You can change this later in the integration's options."
         }
       }
     },
@@ -35,11 +43,13 @@
             "name": "Fan & light defaults",
             "description": "These settings control what happens when you turn on the fan or light without specifying a speed or brightness (e.g., tapping a toggle in your dashboard).",
             "data": {
+              "speed_count": "Number of fan speeds",
               "default_speed": "Default turn-on speed",
               "default_brightness": "Default light brightness"
             },
             "data_description": {
-              "default_speed": "The fan speed used when you turn the fan on without choosing a specific speed.",
+              "speed_count": "How many discrete speeds your fan supports. AC fans are usually 3; DC fans are commonly 6 or 32. Pick a common value or type a custom number.",
+              "default_speed": "The fan speed used when you turn the fan on without choosing a specific speed. Low/Medium/High scale automatically based on the speed count above.",
               "default_brightness": "The brightness used when you turn the light on without choosing a specific level. Set to 0 to use the last brightness."
             }
           },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -29,7 +29,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.fanimation.const import DOMAIN
+from custom_components.fanimation.const import CONF_SPEED_COUNT, DOMAIN
 
 from .conftest import TEST_MAC, TEST_NAME
 
@@ -146,13 +146,14 @@ class TestBluetoothDiscovery:
             # Submit the confirmation form with a custom name
             result = await hass.config_entries.flow.async_configure(
                 result["flow_id"],
-                user_input={CONF_NAME: "Office Fan"},
+                user_input={CONF_NAME: "Office Fan", CONF_SPEED_COUNT: "3"},
             )
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["title"] == "Office Fan"
         assert result["data"][CONF_MAC] == TEST_MAC
         assert result["data"][CONF_NAME] == "Office Fan"
+        assert result["data"][CONF_SPEED_COUNT] == 3  # coerced to int by schema
 
     async def test_discovery_not_fanimation_aborts(self, hass: HomeAssistant) -> None:
         """Discovery of a non-Fanimation device should abort."""
@@ -224,12 +225,14 @@ class TestManualEntry:
                 user_input={
                     CONF_MAC: TEST_MAC,
                     CONF_NAME: TEST_NAME,
+                    CONF_SPEED_COUNT: "6",
                 },
             )
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["title"] == TEST_NAME
         assert result["data"][CONF_MAC] == TEST_MAC.upper()
+        assert result["data"][CONF_SPEED_COUNT] == 6
 
     async def test_manual_unreachable_device_shows_error(self, hass: HomeAssistant) -> None:
         """Unreachable device should show cannot_connect error."""
@@ -247,6 +250,7 @@ class TestManualEntry:
                 user_input={
                     CONF_MAC: TEST_MAC,
                     CONF_NAME: TEST_NAME,
+                    CONF_SPEED_COUNT: "3",
                 },
             )
 
@@ -275,6 +279,7 @@ class TestManualEntry:
                 user_input={
                     CONF_MAC: TEST_MAC,
                     CONF_NAME: TEST_NAME,
+                    CONF_SPEED_COUNT: "3",
                 },
             )
 
@@ -347,6 +352,7 @@ class TestDuplicatePrevention:
                 user_input={
                     CONF_MAC: TEST_MAC,
                     CONF_NAME: TEST_NAME,
+                    CONF_SPEED_COUNT: "3",
                 },
             )
 

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -1,7 +1,9 @@
-"""Tests for the Fanimation fan entity default speed logic.
+"""Tests for the Fanimation fan entity speed handling.
 
-Pure unit tests — no HA test harness required. Test the turn-on
-speed selection logic based on options configuration.
+Pure unit tests — no HA test harness required. Cover:
+ * default-speed turn_on logic for last-used and named presets
+ * slider math (percentage <-> raw speed) for arbitrary speed counts
+ * Issue #1 regression: a fan reporting an out-of-range speed must NOT crash
 """
 
 from __future__ import annotations
@@ -12,16 +14,18 @@ import pytest
 
 from custom_components.fanimation.const import (
     CONF_DEFAULT_SPEED,
+    CONF_SPEED_COUNT,
     DEFAULT_SPEED_LAST_USED,
     SPEED_HIGH,
     SPEED_LOW,
     SPEED_MED,
+    speed_for_preset,
 )
 from custom_components.fanimation.device import FanimationState
 
 
-def _make_fan(default_speed: str = DEFAULT_SPEED_LAST_USED):
-    """Create a FanimationFan with mocked coordinator for unit testing."""
+def _make_fan(default_speed: str = DEFAULT_SPEED_LAST_USED, speed_count: int = 3):
+    """Create a FanimationFan with mocked coordinator and entry for unit testing."""
     from custom_components.fanimation.fan import FanimationFan
 
     mock_coordinator = MagicMock()
@@ -36,7 +40,12 @@ def _make_fan(default_speed: str = DEFAULT_SPEED_LAST_USED):
     mock_coordinator.config_entry.options = {CONF_DEFAULT_SPEED: default_speed}
     mock_coordinator.config_entry.entry_id = "test_entry"
 
-    fan = FanimationFan(mock_coordinator, "test_entry")
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+    mock_entry.options = {CONF_DEFAULT_SPEED: default_speed}
+    mock_entry.data = {CONF_SPEED_COUNT: speed_count}
+
+    fan = FanimationFan(mock_coordinator, mock_entry)
     return fan, mock_coordinator
 
 
@@ -94,3 +103,95 @@ class TestDefaultSpeed:
         await fan.async_turn_on()
 
         mock_coord.device.async_set_state.assert_called_once_with(speed=SPEED_HIGH)
+
+
+class TestSpeedForPreset:
+    """Verify low/medium/high scale proportionally with speed_count."""
+
+    @pytest.mark.parametrize(
+        ("count", "expected_low", "expected_medium", "expected_high"),
+        [
+            (1, 1, 1, 1),  # 1-speed fan: all presets collapse to 1 (clamped, never 0)
+            (3, 1, 2, 3),  # 3-speed AC fan — preserves original behaviour
+            (6, 2, 4, 6),  # 6-speed DC fan
+            (32, 11, 21, 32),  # 32-speed DC fan — close to issue author's (10, 20, 31)
+        ],
+    )
+    def test_preset_mapping(self, count: int, expected_low: int, expected_medium: int, expected_high: int) -> None:
+        assert speed_for_preset("low", count) == expected_low
+        assert speed_for_preset("medium", count) == expected_medium
+        assert speed_for_preset("high", count) == expected_high
+
+    def test_unknown_preset_returns_none(self) -> None:
+        assert speed_for_preset("last_used", 32) is None
+        assert speed_for_preset("turbo", 32) is None
+
+
+class TestSliderMath:
+    """Verify percentage <-> raw-speed translation for any speed_count."""
+
+    @pytest.mark.parametrize(
+        ("count", "raw_speed", "expected_pct"),
+        [
+            # HA's ranged_value_to_percentage((1, N), v) = int(v * 100 // N)
+            (3, 1, 33),
+            (3, 2, 66),
+            (3, 3, 100),
+            (6, 3, 50),
+            (6, 6, 100),
+            (32, 16, 50),
+            (32, 32, 100),
+        ],
+    )
+    def test_percentage_read(self, count: int, raw_speed: int, expected_pct: int) -> None:
+        fan, mock_coord = _make_fan(speed_count=count)
+        mock_coord.data = FanimationState(speed=raw_speed)
+        assert fan.percentage == expected_pct
+
+    @pytest.mark.parametrize(
+        ("count", "percentage", "expected_speed"),
+        [
+            # Round-trip from each speed's percentage back to that speed.
+            # ceil(N * pct/100), clamped to [1, N].
+            (3, 0, 0),  # 0% → off
+            (3, 33, 1),
+            (3, 66, 2),
+            (3, 100, 3),
+            (6, 50, 3),
+            (6, 100, 6),
+            (32, 50, 16),
+            (32, 100, 32),
+            (1, 100, 1),  # 1-speed fan
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_set_percentage(self, count: int, percentage: int, expected_speed: int) -> None:
+        fan, mock_coord = _make_fan(speed_count=count)
+        await fan.async_set_percentage(percentage)
+        mock_coord.device.async_set_state.assert_called_once_with(speed=expected_speed)
+
+    def test_percentage_off_returns_zero(self) -> None:
+        fan, mock_coord = _make_fan(speed_count=32)
+        mock_coord.data = FanimationState(speed=0)
+        assert fan.percentage == 0
+
+
+class TestIssue1Regression:
+    """Regression: a fan reporting an out-of-range speed must not crash the entity.
+
+    Issue #1: a 32-speed DC fan set to speed=5 by RF remote, with the integration
+    misconfigured for speed_count=3, used to raise ValueError and mark the entity
+    unavailable. After the fix, the entity stays available and pegs at 100%.
+    """
+
+    @pytest.mark.parametrize("raw_speed", [4, 5, 16, 32])
+    def test_out_of_range_speed_does_not_raise(self, raw_speed: int) -> None:
+        fan, mock_coord = _make_fan(speed_count=3)
+        mock_coord.data = FanimationState(speed=raw_speed)
+        # Must not raise; clamped to 100%.
+        assert fan.percentage == 100
+
+    def test_in_range_speed_still_works(self) -> None:
+        fan, mock_coord = _make_fan(speed_count=3)
+        mock_coord.data = FanimationState(speed=2)
+        assert fan.percentage == 66

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -8,6 +8,7 @@ Pure unit tests — no HA test harness required. Cover:
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -25,14 +26,24 @@ from custom_components.fanimation.device import FanimationState
 
 
 def _make_fan(default_speed: str = DEFAULT_SPEED_LAST_USED, speed_count: int = 3):
-    """Create a FanimationFan with mocked coordinator and entry for unit testing."""
+    """Create a FanimationFan with mocked coordinator and entry for unit testing.
+
+    ``async_set_state`` echoes the requested speed back as a ``FanimationState`` so
+    that ``_last_speed`` bookkeeping (which now reads from the verified response)
+    behaves as it would against real hardware that accepts the command. Tests that
+    need to simulate firmware rejection or comm failure should override the mock
+    with their own ``return_value``.
+    """
     from custom_components.fanimation.fan import FanimationFan
+
+    async def _echo_state(speed: int | None = None, **_kwargs: Any) -> FanimationState:
+        return FanimationState(speed=speed if speed is not None else 0)
 
     mock_coordinator = MagicMock()
     mock_coordinator.device = MagicMock()
     mock_coordinator.device.mac = "AA:BB:CC:DD:EE:FF"
     mock_coordinator.device.name = "Test Fan"
-    mock_coordinator.device.async_set_state = AsyncMock()
+    mock_coordinator.device.async_set_state = AsyncMock(side_effect=_echo_state)
     mock_coordinator.async_start_fast_poll = AsyncMock()
     mock_coordinator.data = FanimationState(speed=0)
     mock_coordinator.connection_failures = 0
@@ -195,3 +206,61 @@ class TestIssue1Regression:
         fan, mock_coord = _make_fan(speed_count=3)
         mock_coord.data = FanimationState(speed=2)
         assert fan.percentage == 66
+
+
+class TestLastSpeedBookkeeping:
+    """Regression: ``_last_speed`` must reflect what the *hardware accepted*, not
+    what we *asked for*. If the firmware silently rejects an out-of-range speed
+    (BTT9 on a 3-speed fan treats SPEED bytes >= 4 as off), pinning ``_last_speed``
+    to the rejected value puts ``async_turn_on`` into a stuck-off loop: every
+    "Last Used" turn-on resends the bad value and the fan stays off.
+    """
+
+    @pytest.mark.asyncio
+    async def test_last_speed_not_updated_when_hardware_reports_off(self) -> None:
+        """speed_count=6 misconfig on 3-speed fan: requested 5, fan reports off."""
+        fan, mock_coord = _make_fan(speed_count=6)
+        fan._last_speed = SPEED_MED  # last known good
+        mock_coord.device.async_set_state = AsyncMock(
+            return_value=FanimationState(speed=0)  # firmware silently rejected
+        )
+
+        await fan.async_set_percentage(83)  # → raw speed=5
+
+        # Must NOT be pinned to the rejected value, or "Last Used" turn-on will
+        # resend speed=5 forever and the fan will stay off.
+        assert fan._last_speed == SPEED_MED
+
+    @pytest.mark.asyncio
+    async def test_last_speed_synced_to_verified_response(self) -> None:
+        """Successful command: ``_last_speed`` reflects what hardware confirmed."""
+        fan, mock_coord = _make_fan(speed_count=3)
+        mock_coord.device.async_set_state = AsyncMock(return_value=FanimationState(speed=SPEED_MED))
+
+        await fan.async_set_percentage(66)  # → raw speed=2
+
+        assert fan._last_speed == SPEED_MED
+
+    @pytest.mark.asyncio
+    async def test_last_speed_not_updated_on_communication_failure(self) -> None:
+        """If ``async_set_state`` returns None (BLE error), keep prior _last_speed."""
+        fan, mock_coord = _make_fan(speed_count=3)
+        fan._last_speed = SPEED_HIGH
+        mock_coord.device.async_set_state = AsyncMock(return_value=None)
+
+        await fan.async_set_percentage(33)
+
+        assert fan._last_speed == SPEED_HIGH
+
+    @pytest.mark.asyncio
+    async def test_turn_off_does_not_clobber_last_speed(self) -> None:
+        """Turning off must not reset ``_last_speed`` to 0 — turn_on needs it."""
+        fan, mock_coord = _make_fan(speed_count=3)
+        fan._last_speed = SPEED_MED
+        # Hardware reports off after explicit turn-off (this is the normal case).
+        mock_coord.device.async_set_state = AsyncMock(return_value=FanimationState(speed=0))
+
+        await fan.async_turn_off()
+
+        # Still SPEED_MED so a subsequent "Last Used" turn-on goes back to medium.
+        assert fan._last_speed == SPEED_MED

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -23,9 +23,11 @@ from custom_components.fanimation.const import (
     CONF_DEFAULT_BRIGHTNESS,
     CONF_DEFAULT_SPEED,
     CONF_NOTIFY_ON_DISCONNECT,
+    CONF_SPEED_COUNT,
     CONF_UNAVAILABLE_THRESHOLD,
     DEFAULT_BRIGHTNESS_LAST_USED,
     DEFAULT_NOTIFY_ON_DISCONNECT,
+    DEFAULT_SPEED_COUNT,
     DEFAULT_SPEED_LAST_USED,
     DEFAULT_UNAVAILABLE_THRESHOLD,
     DOMAIN,
@@ -82,6 +84,7 @@ class TestOptionsFlow:
             result["flow_id"],
             user_input={
                 "defaults": {
+                    CONF_SPEED_COUNT: "32",
                     CONF_DEFAULT_SPEED: "medium",
                     CONF_DEFAULT_BRIGHTNESS: 75,
                 },
@@ -92,6 +95,7 @@ class TestOptionsFlow:
             },
         )
         assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert mock_entry.options[CONF_SPEED_COUNT] == 32  # coerced to int
         assert mock_entry.options[CONF_DEFAULT_SPEED] == "medium"
         assert mock_entry.options[CONF_DEFAULT_BRIGHTNESS] == 75
         assert mock_entry.options[CONF_NOTIFY_ON_DISCONNECT] is False
@@ -106,6 +110,7 @@ class TestOptionsFlow:
             result["flow_id"],
             user_input={
                 "defaults": {
+                    CONF_SPEED_COUNT: str(DEFAULT_SPEED_COUNT),
                     CONF_DEFAULT_SPEED: DEFAULT_SPEED_LAST_USED,
                     CONF_DEFAULT_BRIGHTNESS: DEFAULT_BRIGHTNESS_LAST_USED,
                 },
@@ -116,5 +121,6 @@ class TestOptionsFlow:
             },
         )
         assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert mock_entry.options[CONF_SPEED_COUNT] == DEFAULT_SPEED_COUNT
         assert mock_entry.options[CONF_DEFAULT_SPEED] == DEFAULT_SPEED_LAST_USED
         assert mock_entry.options[CONF_DEFAULT_BRIGHTNESS] == DEFAULT_BRIGHTNESS_LAST_USED


### PR DESCRIPTION
## Summary

Makes the fan entity adapt to hardware with more than 3 speeds. Resolves the `ValueError: The item "X" is not in "[1, 2, 3]"` crash (#1) on DC fans with the TR305 FanSync remote.

Two commits:
- `dfad993` — per-fan configurable speed count, slider + scaled Low/Medium/High presets
- `298a6b2` — follow-up fix for a stuck-off loop when `speed_count` is misconfigured and `default_speed = "Last Used"`

## What changed

**Dynamic speed count (1–99, default 3)**
- New **Number of fan speeds** field in the setup dialog and in the per-fan options flow.
- Dropdown of common values (1, 3, 6, 32) with `custom_value=True` so unusual hardware can type any integer.
- Fan UI becomes a slider with `N` discrete steps once set. `low` / `medium` / `high` presets scale proportionally with `N` — on a 32-speed fan they map to 11 / 21 / 32 instead of 1 / 2 / 3.
- Uses HA's `ranged_value_to_percentage` / `percentage_to_ranged_value` helpers; no more `ORDERED_NAMED_FAN_SPEEDS` list.
- Reading a fan state outside `[1, N]` no longer raises — it's clamped to 100% so RF-remote-triggered out-of-range speeds don't knock the entity unavailable.

**Stuck-off loop fix (`298a6b2`)**
If `speed_count` is misconfigured (e.g. 6 on a 3-speed fan), the BTCR9 firmware silently turns the motor off when it receives a SPEED byte above the physical max. Previously `_last_speed` was updated pre-write, pinning it to the rejected value and trapping `async_turn_on` with `default_speed = "Last Used"` in a loop that resent the bad speed forever. Now `_last_speed` is updated from the verified GET_STATUS response returned by `device.async_set_state`, and only when `state.speed > 0`.

## Tests

- 4 new unit tests in `tests/test_fan.py` covering the bookkeeping fix: hardware-reject, verified-response sync, comm-failure preserve, and turn-off preserve.
- Parameterised slider-math tests for speed counts 1 / 3 / 6 / 32.
- Regression test for #1 itself (out-of-range `speed` no longer raises).

## Test Plan

- [x] Verified on maintainer's hardware — 3-speed AC fans, BTCR9 + BTT9, HA Yellow 2026.2.3.
- [x] Verified by @JesusSanchezLopez on his DC hardware — Fanimation Odyn 84" (32-speed, TR305 remote) and a 6-speed DC fan. Confirmed working on both AC and DC on 2026-04-17.
- [x] CI green on push (hassfest, HACS validate, ruff, pytest).

## Credits

Bug reported and originally diagnosed by @JesusSanchezLopez (#1, #2). He also tested this implementation on the multi-speed DC hardware the maintainer doesn't have access to. Closes #1 and supersedes #2.