### PR TITLE
Fix config-flow schema crash when adding a fan manually

### DIFF
--- a/custom_components/fanimation/config_flow.py
+++ b/custom_components/fanimation/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import voluptuous as vol
@@ -11,6 +12,7 @@ from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlowWithConfigEntry
 from homeassistant.const import CONF_MAC, CONF_NAME
 from homeassistant.data_entry_flow import section
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.selector import (
     NumberSelector,
     NumberSelectorConfig,
@@ -45,6 +47,9 @@ from .const import (
 )
 
 SERVICE_UUID = "0000e000-0000-1000-8000-00805f9b34fb"
+
+# Canonical MAC form after format_mac() normalization: lowercase colon-separated.
+_MAC_RE = re.compile(r"^([0-9a-f]{2}:){5}[0-9a-f]{2}$")
 
 
 def _speed_count_field() -> vol.All:
@@ -179,39 +184,47 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        """Handle manual setup."""
+        """Handle manual setup.
+
+        MAC validation runs in the handler, not in the voluptuous schema:
+        ``vol.Match`` is not JSON-serializable by ``voluptuous_serialize`` and
+        causes the frontend to error when rendering the form (Issue #5).
+        Accepting ``str`` in the schema and validating here also lets us
+        normalize colon/dash/dot/bare-hex input via ``format_mac``.
+        """
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            mac = user_input[CONF_MAC].upper()
-            name = user_input[CONF_NAME]
-
-            # Set unique ID to prevent duplicates
-            await self.async_set_unique_id(mac)
-            self._abort_if_unique_id_configured()
-
-            # Test-before-configure: verify the device is reachable
-            # and has the expected GATT characteristics
-            if not await self._async_validate_device(mac):
-                errors["base"] = "cannot_connect"
+            normalized = format_mac(user_input[CONF_MAC].strip())
+            if not _MAC_RE.match(normalized):
+                errors[CONF_MAC] = "invalid_mac"
             else:
-                return self.async_create_entry(
-                    title=name,
-                    data={
-                        CONF_MAC: mac,
-                        CONF_NAME: name,
-                        CONF_SPEED_COUNT: user_input[CONF_SPEED_COUNT],
-                    },
-                )
+                mac = normalized.upper()
+                name = user_input[CONF_NAME]
+
+                # Set unique ID to prevent duplicates
+                await self.async_set_unique_id(mac)
+                self._abort_if_unique_id_configured()
+
+                # Test-before-configure: verify the device is reachable
+                # and has the expected GATT characteristics
+                if not await self._async_validate_device(mac):
+                    errors["base"] = "cannot_connect"
+                else:
+                    return self.async_create_entry(
+                        title=name,
+                        data={
+                            CONF_MAC: mac,
+                            CONF_NAME: name,
+                            CONF_SPEED_COUNT: user_input[CONF_SPEED_COUNT],
+                        },
+                    )
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_MAC): vol.All(
-                        str,
-                        vol.Match(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$"),
-                    ),
+                    vol.Required(CONF_MAC): str,
                     vol.Required(CONF_NAME, default="Fanimation Fan"): str,
                     vol.Required(CONF_SPEED_COUNT, default=str(DEFAULT_SPEED_COUNT)): _speed_count_field(),
                 }

--- a/custom_components/fanimation/strings.json
+++ b/custom_components/fanimation/strings.json
@@ -32,6 +32,7 @@
     },
     "abort": {
       "already_configured": "This fan is already configured.",
+      "already_in_progress": "This fan is already being set up (it was auto-discovered). Finish or cancel that setup instead of adding it manually.",
       "not_fanimation": "This device does not appear to be a Fanimation fan (expected GATT characteristics not found)."
     }
   },

--- a/custom_components/fanimation/strings.json
+++ b/custom_components/fanimation/strings.json
@@ -27,6 +27,7 @@
     },
     "error": {
       "cannot_connect": "Could not connect to the fan. Make sure it is powered on and within Bluetooth range.",
+      "invalid_mac": "That doesn't look like a MAC address. Use the form AA:BB:CC:DD:EE:FF (colons, dashes, or no separator all work).",
       "unknown": "An unexpected error occurred."
     },
     "abort": {

--- a/custom_components/fanimation/translations/en.json
+++ b/custom_components/fanimation/translations/en.json
@@ -32,6 +32,7 @@
     },
     "abort": {
       "already_configured": "This fan is already configured.",
+      "already_in_progress": "This fan is already being set up (it was auto-discovered). Finish or cancel that setup instead of adding it manually.",
       "not_fanimation": "This device does not appear to be a Fanimation fan (expected GATT characteristics not found)."
     }
   },

--- a/custom_components/fanimation/translations/en.json
+++ b/custom_components/fanimation/translations/en.json
@@ -27,6 +27,7 @@
     },
     "error": {
       "cannot_connect": "Could not connect to the fan. Make sure it is powered on and within Bluetooth range.",
+      "invalid_mac": "That doesn't look like a MAC address. Use the form AA:BB:CC:DD:EE:FF (colons, dashes, or no separator all work).",
       "unknown": "An unexpected error occurred."
     },
     "abort": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -234,6 +234,63 @@ class TestManualEntry:
         assert result["data"][CONF_MAC] == TEST_MAC.upper()
         assert result["data"][CONF_SPEED_COUNT] == 6
 
+    async def test_manual_invalid_mac_shows_error(self, hass: HomeAssistant) -> None:
+        """Garbled MAC input should re-show the form with invalid_mac error.
+
+        Regression guard for Issue #5: validation runs in the handler, not in
+        the voluptuous schema (vol.Match was not JSON-serializable and broke
+        form rendering entirely).
+        """
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_MAC: "not-a-mac-address",
+                CONF_NAME: TEST_NAME,
+                CONF_SPEED_COUNT: "3",
+            },
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"] == {CONF_MAC: "invalid_mac"}
+
+    async def test_manual_accepts_dash_separated_mac(self, hass: HomeAssistant) -> None:
+        """Dash-separated MAC should be normalized and accepted."""
+        with (
+            patch(
+                "custom_components.fanimation.config_flow.bluetooth.async_ble_device_from_address",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "custom_components.fanimation.config_flow.establish_connection",
+            ) as mock_conn,
+        ):
+            mock_client = AsyncMock()
+            mock_client.services = _mock_services_with_chars()
+            mock_client.disconnect = AsyncMock()
+            mock_conn.return_value = mock_client
+
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_USER},
+            )
+
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={
+                    CONF_MAC: TEST_MAC.replace(":", "-"),
+                    CONF_NAME: TEST_NAME,
+                    CONF_SPEED_COUNT: "3",
+                },
+            )
+
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_MAC] == TEST_MAC.upper()
+
     async def test_manual_unreachable_device_shows_error(self, hass: HomeAssistant) -> None:
         """Unreachable device should show cannot_connect error."""
         with patch(

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,95 @@
+"""Translation-completeness tests — pure data, no Home Assistant harness needed.
+
+Guards the class of bug behind the Issue #5 follow-up (an error message rendering
+as a raw key in the UI). For a custom component, Home Assistant serves
+``translations/en.json`` to the frontend at runtime — ``strings.json`` is only the
+developer source — so any key present in one file but missing from the other
+renders untranslated. These tests parse the JSON and ``config_flow.py`` directly
+(no integration import), so they run on every platform, including the Windows
+unit-test runs that skip the HA-harness config-flow tests.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+_COMPONENT = Path(__file__).resolve().parent.parent / "custom_components" / "fanimation"
+_STRINGS = _COMPONENT / "strings.json"
+_TRANSLATIONS = _COMPONENT / "translations" / "en.json"
+_CONFIG_FLOW = _COMPONENT / "config_flow.py"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _leaf_paths(obj: Any, prefix: str = "") -> list[str]:
+    """Return dotted paths to every leaf (non-dict) value in a nested dict."""
+    if isinstance(obj, dict):
+        paths: list[str] = []
+        for key, value in obj.items():
+            child = f"{prefix}.{key}" if prefix else key
+            paths.extend(_leaf_paths(value, child))
+        return paths
+    return [prefix]
+
+
+def test_strings_and_translations_have_identical_keys() -> None:
+    """``strings.json`` (dev source) and ``translations/en.json`` (runtime) must match.
+
+    HA serves ``translations/en.json`` to the frontend for custom components, so a
+    key that exists only in ``strings.json`` renders as a raw key in the UI. This
+    parity check covers the whole tree, so config-flow, options, selector, and
+    entity keys (including ones added by later features) are all guarded for free.
+    """
+    s_keys = set(_leaf_paths(_load(_STRINGS)))
+    t_keys = set(_leaf_paths(_load(_TRANSLATIONS)))
+    assert s_keys == t_keys, (
+        "strings.json and translations/en.json keys differ: "
+        f"only in strings={sorted(s_keys - t_keys)}; only in translations={sorted(t_keys - s_keys)}"
+    )
+
+
+def _config_flow_error_and_abort_keys() -> tuple[set[str], set[str]]:
+    """Extract (error_keys, abort_keys) referenced as string literals in config_flow.py.
+
+    Catches ``errors[...] = "key"`` assignments and ``async_abort(reason="key")``
+    calls. HA-core-emitted aborts (e.g. ``already_configured`` from
+    ``_abort_if_unique_id_configured``, ``already_in_progress`` from the flow
+    manager) are not literals here and are covered by the parity test instead.
+    """
+    tree = ast.parse(_CONFIG_FLOW.read_text(encoding="utf-8"))
+    error_keys: set[str] = set()
+    abort_keys: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Subscript)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "errors"
+                    and isinstance(node.value, ast.Constant)
+                    and isinstance(node.value.value, str)
+                ):
+                    error_keys.add(node.value.value)
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "async_abort":
+            for keyword in node.keywords:
+                if keyword.arg == "reason" and isinstance(keyword.value, ast.Constant):
+                    abort_keys.add(keyword.value.value)
+    return error_keys, abort_keys
+
+
+def test_config_flow_error_and_abort_keys_are_translated() -> None:
+    """Every error/abort key set in config_flow.py exists under config.error/abort in both files."""
+    error_keys, abort_keys = _config_flow_error_and_abort_keys()
+    assert error_keys, "expected at least one errors[...] assignment in config_flow.py"
+
+    for name, data in (("strings.json", _load(_STRINGS)), ("translations/en.json", _load(_TRANSLATIONS))):
+        config = data.get("config", {})
+        missing_errors = error_keys - set(config.get("error", {}))
+        missing_aborts = abort_keys - set(config.get("abort", {}))
+        assert not missing_errors, f"{name}: config.error is missing {sorted(missing_errors)}"
+        assert not missing_aborts, f"{name}: config.abort is missing {sorted(missing_aborts)}"


### PR DESCRIPTION
## Problem

Adding a fan via the manual MAC path (**Settings → Devices & Services → Add Integration → Fanimation BLE Ceiling Fan**) crashed the config flow:

```
ValueError: Unable to convert schema: Match('^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$', ...)
```

`voluptuous`'s `vol.Match` is not JSON-serializable by `voluptuous_serialize`, so the frontend errored while rendering the form. Reported in #5 (hit when adding a second fan).

## Fix

- Move MAC validation out of the voluptuous schema and into the step handler. The schema now accepts a plain `str`; the handler normalizes the input with `format_mac` (so colon-, dash-, dot-separated, and bare-hex MACs all work) and validates it with a compiled regex, surfacing an inline `invalid_mac` error instead of a traceback.

## Translation hardening (follow-up from testing in #5)

- Add `config.abort.already_in_progress` to `strings.json` / `translations/en.json`. Home Assistant core does not reliably auto-translate this reason for custom integrations, so manually adding an already-auto-discovered fan showed a raw key.
- Add `tests/test_translations.py`: a pure-data guard (no HA harness) asserting `strings.json` and `translations/en.json` have identical keys, and that every error/abort key used in `config_flow.py` is defined in both — so an untranslated config-flow message can't ship again.

Note: the `invalid_mac` message was already defined correctly on this branch; the untranslated rendering seen during testing was almost certainly a translation-cache artifact of hot-swapping files into a running install, not a missing key.

## Testing

- Confirmed working by the reporter in #5: form renders, invalid MACs show an inline error, a valid MAC creates the entry.
- `tests/test_translations.py` passes locally.
- The config-flow regression suite (`tests/test_config_flow.py`, including the MAC-validation tests) runs in CI.

Closes #5
