### PR TITLE
ci: bump actions/checkout and actions/setup-python to Node 24 runtime

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run hassfest validation
         uses: home-assistant/actions/hassfest@master
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run HACS validation
         uses: hacs/action@main


### PR DESCRIPTION
## What

Bump GitHub Actions to the latest majors that run on the **Node.js 24** runtime, across all three workflow files (`tests.yml`, `validate.yml`, `lint.yml`):

| Action | Before | After | Node 24 since |
|--------|--------|-------|---------------|
| `actions/checkout` | `@v4` | `@v6` | v5.0.0 |
| `actions/setup-python` | `@v5` | `@v6` | v6.0.0 |

## Why

CI was emitting:

> Node.js 20 actions are deprecated... Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

The pinned `@v4`/`@v5` tags resolve to `action.yml` files declaring `using: node20`. The new `@v6` tags declare `using: node24`, clearing the warning.

## Notes

- The `home-assistant/actions/hassfest@master` and `hacs/action@main` steps track branches rather than version tags, so they pick up Node 24 automatically and were left unchanged.
- Usage is trivial (bare checkout + `python-version: "3.13"`), so the v5→v6 / v6 major bumps carry no behavioral change here; the only breaking change in either is the runtime itself (setup-python v6 requires runner ≥ v2.327.1, which GitHub-hosted `ubuntu-latest` satisfies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)