### PR TITLE
Restore reverse-direction control for DC fans (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Per-fan options are configurable via **Settings → Devices → Configure** ([sc
 - **Number of fan speeds** — pick a common value (1, 3, 6, 32) or type a custom number. Low/Medium/High and the slider scale automatically. ([dropdown](docs/screenshots/options-flow-speed-count-dropdown.png))
 - **Default turn-on speed** — Last used, Low, Medium, or High (Low/Medium/High map proportionally to your fan's speed count). ([dropdown](docs/screenshots/options-flow-default-speed-dropdown.png))
 - **Default light brightness** — 0 = last used, 1-100 = fixed level
+- **Change direction** — adds a forward/reverse control; auto-on for DC fans, off for AC. Turn on manually if your fan supports electronic direction control which wasn't detected by the integration.
 - **Disconnect notification** — persistent alert on first BLE failure
 - **Unavailable threshold** — how many poll failures before entities go grey
 
@@ -43,7 +44,7 @@ The BTCR9 BLE protocol has been reverse-engineered and verified on real AC hardw
 | Feature | Range | Status |
 |---------|-------|--------|
 | Fan speed | Off, then 1 up to your fan's max speed (set speed count in options — default 3, up to 99) | Verified on 3-speed AC and 6- & 32-speed DC fans |
-| Fan direction | Forward / Reverse | Not exposed in 1.2.1 — community testing in progress ([#4](https://github.com/sumgup0/FanimationHA-AC-BT/issues/4)) |
+| Fan direction | Forward / Reverse | DC fans auto-detected and option is shown by default ([#4](https://github.com/sumgup0/FanimationHA-AC-BT/issues/4)), but can toggle in per-fan settings |
 | Downlight brightness | 0–100% | Verified |
 | Sleep timer | 0–360 minutes | Verified |
 
@@ -85,7 +86,7 @@ This integration talks to the fan's **Bluetooth receiver**, so it should work wi
 
 - Tested on a **3-speed capacitor-switched AC motor**. AC fans with different speed counts should also work — set **Number of fan speeds** in options to match.
 - **DC motors** (e.g. 6- and 32-speed) are community-tested and supported.
-- **Direction / reverse**: the specific AC fan tested does not change direction electronically (it reverses via a physical switch on the motor housing). Other fans — particularly DC models — may support electronic reverse; that's being investigated in [Issue #4](https://github.com/sumgup0/FanimationHA-AC-BT/issues/4). Direction control is not exposed in 1.2.1.
+- **Direction / reverse**: DC motors reverse electronically, and the integration **auto-detects** them (via the `fan_type` byte) to show a forward/reverse control — with a **Change direction** toggle in options to override. The tested AC fan does not reverse electronically (it uses a physical switch on the motor housing), so the control stays hidden for AC but can be overridden in options. Confirmed on real DC hardware in [Issue #4](https://github.com/sumgup0/FanimationHA-AC-BT/issues/4).
 
 **Known-working fans:**
 

--- a/custom_components/fanimation/config_flow.py
+++ b/custom_components/fanimation/config_flow.py
@@ -29,6 +29,7 @@ from .const import (
     CONF_DEFAULT_SPEED,
     CONF_NOTIFY_ON_DISCONNECT,
     CONF_SPEED_COUNT,
+    CONF_SUPPORTS_REVERSE,
     CONF_UNAVAILABLE_THRESHOLD,
     DEFAULT_BRIGHTNESS_LAST_USED,
     DEFAULT_NOTIFY_ON_DISCONNECT,
@@ -44,6 +45,7 @@ from .const import (
     MAX_UNAVAILABLE_THRESHOLD,
     MIN_SPEED_COUNT,
     SPEED_COUNT_COMMON,
+    fan_type_supports_reverse,
 )
 
 SERVICE_UUID = "0000e000-0000-1000-8000-00805f9b34fb"
@@ -272,6 +274,11 @@ class FanimationOptionsFlow(OptionsFlowWithConfigEntry):
             CONF_SPEED_COUNT,
             self.config_entry.data.get(CONF_SPEED_COUNT, DEFAULT_SPEED_COUNT),
         )
+        # Default the reverse toggle from the detected fan type (ON only for
+        # confirmed-reversible DC fans), read from the live coordinator state.
+        coordinator = getattr(self.config_entry, "runtime_data", None)
+        data = getattr(coordinator, "data", None)
+        detected_reverse = data is not None and fan_type_supports_reverse(data.fan_type)
         return vol.Schema(
             {
                 vol.Required(
@@ -297,6 +304,10 @@ class FanimationOptionsFlow(OptionsFlowWithConfigEntry):
                     CONF_DEFAULT_BRIGHTNESS,
                     default=self.options.get(CONF_DEFAULT_BRIGHTNESS, DEFAULT_BRIGHTNESS_LAST_USED),
                 ): NumberSelector(NumberSelectorConfig(min=0, max=100, step=1, mode=NumberSelectorMode.SLIDER)),
+                vol.Required(
+                    CONF_SUPPORTS_REVERSE,
+                    default=self.options.get(CONF_SUPPORTS_REVERSE, detected_reverse),
+                ): bool,
             }
         )
 

--- a/custom_components/fanimation/const.py
+++ b/custom_components/fanimation/const.py
@@ -34,6 +34,18 @@ SPEED_LOW = 1
 SPEED_MED = 2
 SPEED_HIGH = 3
 
+# Direction (protocol byte[3])
+DIR_FORWARD = 0
+DIR_REVERSE = 1
+
+# fan_type (protocol byte[8]) values observed so far: AC capacitor-switched fans
+# report 0 (the direction byte is accepted but has no physical effect) and DC
+# fans report 2 (electronic reverse works, verified). The reverse-direction
+# control therefore defaults ON only for the confirmed-reversible DC value;
+# every other fan_type defaults OFF and can be enabled manually. Refine as more
+# samples arrive — diagnostics captures byte[8].
+REVERSIBLE_FAN_TYPE = 2
+
 # Speed count is per-fan and user-configurable (AC fans typically 3, DC fans 6/32).
 # Common values surfaced as dropdown options; users can type any int in [MIN, MAX].
 DEFAULT_SPEED_COUNT = 3
@@ -60,6 +72,7 @@ CONF_DEFAULT_BRIGHTNESS = "default_brightness"
 CONF_NOTIFY_ON_DISCONNECT = "notify_on_disconnect"
 CONF_UNAVAILABLE_THRESHOLD = "unavailable_threshold"
 CONF_SPEED_COUNT = "speed_count"
+CONF_SUPPORTS_REVERSE = "supports_reverse"
 
 # Option defaults
 DEFAULT_SPEED_LAST_USED = "last_used"
@@ -86,3 +99,12 @@ def speed_for_preset(preset: str, count: int) -> int | None:
     if preset == DEFAULT_SPEED_HIGH:
         return count
     return None
+
+
+def fan_type_supports_reverse(fan_type: int) -> bool:
+    """Return True for fan types known to reverse electronically (DC motors).
+
+    Used to default the opt-in reverse-direction control: ON for the confirmed
+    DC value, OFF for AC (0) and any not-yet-seen type. The user can override.
+    """
+    return fan_type == REVERSIBLE_FAN_TYPE

--- a/custom_components/fanimation/device.py
+++ b/custom_components/fanimation/device.py
@@ -176,6 +176,7 @@ class FanimationDevice:
     async def async_set_state(
         self,
         speed: int | None = None,
+        direction: int | None = None,
         downlight: int | None = None,
         timer_minutes: int | None = None,
     ) -> FanimationState | None:
@@ -184,9 +185,10 @@ class FanimationDevice:
         Only the provided fields are changed; all others are preserved
         from the current fan state (read via GET_STATUS first).
 
-        Note: Direction is not exposed — AC motor fans with the BTCR9
-        controller do not support electronic direction change. The
-        direction byte is always preserved from the current state.
+        ``direction`` is only ever passed by the fan entity when the user has a
+        reverse-capable fan (DC). AC callers omit it, so the current direction
+        byte is preserved untouched — AC behaviour is identical to having no
+        direction control at all.
         """
         async with self._lock:
             await self._ensure_connected()
@@ -205,16 +207,17 @@ class FanimationDevice:
 
             # Merge: use provided values, fall back to current state
             new_speed = speed if speed is not None else current.speed
+            new_direction = direction if direction is not None else current.direction
             new_downlight = downlight if downlight is not None else current.downlight
             new_timer = timer_minutes if timer_minutes is not None else current.timer_minutes
             timer_hi = (new_timer >> 8) & 0xFF
             timer_lo = new_timer & 0xFF
 
-            # Send SET_STATE (direction always preserved from current state)
+            # Send SET_STATE (direction preserved unless a reverse-capable caller set it)
             set_packet = self._build_packet(
                 CMD_SET_STATE,
                 speed=new_speed,
-                direction=current.direction,
+                direction=new_direction,
                 uplight=0,
                 downlight=new_downlight,
                 timer_hi=timer_hi,

--- a/custom_components/fanimation/fan.py
+++ b/custom_components/fanimation/fan.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import math
 from typing import Any
 
-from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.components.fan import (
+    DIRECTION_FORWARD,
+    DIRECTION_REVERSE,
+    FanEntity,
+    FanEntityFeature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.percentage import (
@@ -17,10 +22,14 @@ from . import FanimationConfigEntry
 from .const import (
     CONF_DEFAULT_SPEED,
     CONF_SPEED_COUNT,
+    CONF_SUPPORTS_REVERSE,
     DEFAULT_SPEED_COUNT,
     DEFAULT_SPEED_LAST_USED,
+    DIR_FORWARD,
+    DIR_REVERSE,
     SPEED_LOW,
     SPEED_OFF,
+    fan_type_supports_reverse,
     speed_for_preset,
 )
 from .coordinator import FanimationCoordinator
@@ -40,7 +49,6 @@ async def async_setup_entry(
 class FanimationFan(FanimationEntity, FanEntity):
     """Fanimation ceiling fan entity."""
 
-    _attr_supported_features = FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
     _attr_name = None  # Primary entity — uses device name only
 
     def __init__(
@@ -58,6 +66,17 @@ class FanimationFan(FanimationEntity, FanEntity):
         )
         self._attr_speed_count = self._speed_count
         self._last_speed = SPEED_LOW  # default for turn_on without speed
+
+        # Reverse direction is opt-in. It defaults ON only for fan types known to
+        # reverse electronically (DC); the options toggle overrides either way.
+        # supported_features is fixed at construction and the integration reloads
+        # on options change, so toggling re-creates the entity with the right set.
+        detected = coordinator.data is not None and fan_type_supports_reverse(coordinator.data.fan_type)
+        self._supports_reverse: bool = entry.options.get(CONF_SUPPORTS_REVERSE, detected)
+        features = FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+        if self._supports_reverse:
+            features |= FanEntityFeature.DIRECTION
+        self._attr_supported_features = features
 
     @property
     def is_on(self) -> bool | None:
@@ -83,6 +102,17 @@ class FanimationFan(FanimationEntity, FanEntity):
         # otherwise extrapolate above 100% and break the slider UI.
         clamped = max(1, min(self._speed_count, speed))
         return ranged_value_to_percentage((1, self._speed_count), clamped)
+
+    @property
+    def current_direction(self) -> str | None:
+        """Return the current rotation direction from verified device state (byte[3]).
+
+        Only meaningful when reverse support is enabled; the probe confirmed
+        byte[3] reads back reliably on reverse-capable (DC) fans.
+        """
+        if self.coordinator.data is None:
+            return None
+        return DIRECTION_REVERSE if self.coordinator.data.direction == DIR_REVERSE else DIRECTION_FORWARD
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -117,6 +147,17 @@ class FanimationFan(FanimationEntity, FanEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
         await self._async_set_speed(SPEED_OFF)
+
+    async def async_set_direction(self, direction: str) -> None:
+        """Set the fan rotation direction.
+
+        Reverse-capable (DC) fans change direction instantly — whether stopped or
+        spinning — so this just sends the new direction and refreshes. No
+        stop-and-wait sequence is needed (confirmed by hardware probe).
+        """
+        new_dir = DIR_REVERSE if direction == DIRECTION_REVERSE else DIR_FORWARD
+        await self.coordinator.device.async_set_state(direction=new_dir)
+        await self.coordinator.async_start_fast_poll()
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set fan speed by percentage."""

--- a/custom_components/fanimation/manifest.json
+++ b/custom_components/fanimation/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/sumgup0/FanimationHA-AC-BT/issues",
   "loggers": ["custom_components.fanimation"],
   "requirements": ["bleak-retry-connector>=4.0.0"],
-  "version": "1.2.1"
+  "version": "1.3.0"
 }

--- a/custom_components/fanimation/strings.json
+++ b/custom_components/fanimation/strings.json
@@ -47,12 +47,14 @@
             "data": {
               "speed_count": "Number of fan speeds",
               "default_speed": "Default turn-on speed",
-              "default_brightness": "Default light brightness"
+              "default_brightness": "Default light brightness",
+              "supports_reverse": "Change direction"
             },
             "data_description": {
               "speed_count": "How many discrete speeds your fan supports. AC fans are usually 3; DC fans are commonly 6 or 32. Pick a common value or type a custom number.",
               "default_speed": "The fan speed used when you turn the fan on without choosing a specific speed. Low/Medium/High scale automatically based on the speed count above.",
-              "default_brightness": "The brightness used when you turn the light on without choosing a specific level. Set to 0 to use the last brightness."
+              "default_brightness": "The brightness used when you turn the light on without choosing a specific level. Set to 0 to use the last brightness.",
+              "supports_reverse": "Adds a forward/reverse control to the fan. Defaults on for DC fans that reverse electronically and off for AC fans (which change direction with a switch on the motor). Turn it on manually if your DC fan wasn't auto-detected."
             }
           },
           "connection": {

--- a/custom_components/fanimation/translations/en.json
+++ b/custom_components/fanimation/translations/en.json
@@ -47,12 +47,14 @@
             "data": {
               "speed_count": "Number of fan speeds",
               "default_speed": "Default turn-on speed",
-              "default_brightness": "Default light brightness"
+              "default_brightness": "Default light brightness",
+              "supports_reverse": "Change direction"
             },
             "data_description": {
               "speed_count": "How many discrete speeds your fan supports. AC fans are usually 3; DC fans are commonly 6 or 32. Pick a common value or type a custom number.",
               "default_speed": "The fan speed used when you turn the fan on without choosing a specific speed. Low/Medium/High scale automatically based on the speed count above.",
-              "default_brightness": "The brightness used when you turn the light on without choosing a specific level. Set to 0 to use the last brightness."
+              "default_brightness": "The brightness used when you turn the light on without choosing a specific level. Set to 0 to use the last brightness.",
+              "supports_reverse": "Adds a forward/reverse control to the fan. Defaults on for DC fans that reverse electronically and off for AC fans (which change direction with a switch on the motor). Turn it on manually if your DC fan wasn't auto-detected."
             }
           },
           "connection": {

--- a/docs/BTCR9-BLE-Protocol-Reference.md
+++ b/docs/BTCR9-BLE-Protocol-Reference.md
@@ -134,7 +134,7 @@ Field:  START  CMD    SPEED   DIR    UPLIGHT  DOWNLIGHT TIMER_HI  TIMER_LO  FANT
 | 5 | DOWNLIGHT | Downlight brightness: 0=off, 1-100=percent |
 | 6 | TIMER_HI | Sleep timer high byte (big-endian, in minutes) |
 | 7 | TIMER_LO | Sleep timer low byte (big-endian, in minutes) |
-| 8 | FANTYPE | Fan type selector (unused on BTCR9, always 0) |
+| 8 | FANTYPE | Fan type / motor class: `0` on the tested AC fan, `2` on a community-tested DC fan (see [Direction](#8-direction)) |
 | 9 | CHECKSUM | `sum(bytes[0] through bytes[8]) & 0xFF` |
 
 ### Checksum Calculation
@@ -229,11 +229,11 @@ Other Fanimation BLE fans likely fall somewhere in this range. The Home Assistan
 | 0 | Forward | Standard airflow direction (default) |
 | 1 | Reverse | Reversed airflow |
 
-**⚠️ NOT SUPPORTED on the AC motor tested for this integration.** Testing on BTCR9 hardware with a capacitor-switched AC motor confirmed that the direction byte is accepted in SET_STATE but has no physical effect — the fan continues spinning in the same direction. The verification GET_STATUS always returns direction=0 (forward) regardless of the value sent. The BTT9 physical remote also has no reverse button.
+**Motor-dependent — works on DC motors, not on the tested AC motor.** On a capacitor-switched **AC** motor (`fan_type`=0) the direction byte is accepted in SET_STATE but has no physical effect: the fan keeps spinning the same way and a follow-up GET_STATUS returns direction=0 (forward) regardless of the value sent. The BTT9 physical remote also has no reverse button. AC motors change direction with a physical DPDT switch on the motor housing.
 
-The direction byte likely works on Fanimation DC motor models that support electronic reverse, but this has not yet been confirmed by community testing. Capacitor-switched AC motors require a physical DPDT switch on the motor housing to change direction.
+On a **DC** motor (`fan_type`=2) electronic reverse works: community testing (#4) confirmed the blades physically reverse — instantly, whether the fan is stopped or spinning — and GET_STATUS reads the new direction back reliably in byte[3].
 
-The Home Assistant integration does not expose direction control. The direction byte is always preserved from the current GET_STATUS response during read-before-write operations.
+The Home Assistant integration exposes a direction control for fans detected as reverse-capable (`fan_type`=2), with an options toggle to override the auto-detection. For AC fans the direction byte is preserved untouched from the current GET_STATUS during read-before-write.
 
 ---
 
@@ -330,9 +330,9 @@ This caused a "stuck-off loop": a fan configured for too many speeds in Home Ass
 
 The BTCR9 only accepts one BLE connection at a time. If the FanSync app is connected, your script cannot connect, and vice versa. Make sure to disconnect one before connecting the other.
 
-### Direction Change Does Not Work on the Tested AC Motor
+### Direction Change Is Motor-Dependent
 
-The direction byte (byte[3]) is accepted in SET_STATE but has no physical effect on the capacitor-switched AC motor tested for this integration. The BLE chip echoes the value in the SET_STATE response, but the verification GET_STATUS always returns 0 (forward). This feature likely works on Fanimation DC motor fans but has not yet been confirmed by community testing. See [Section 8: Direction](#8-direction) for details.
+The direction byte (byte[3]) works on DC motors but not on the capacitor-switched AC motor tested for this integration. On the AC fan (`fan_type`=0) the BLE chip echoes the value in the SET_STATE response, but a follow-up GET_STATUS reverts to 0 (forward) — no physical effect. On a community-tested DC fan (`fan_type`=2) the blades physically reverse and GET_STATUS reads the new value back. See [Section 8: Direction](#8-direction) for details.
 
 ### RF Remote and BLE Are Independent
 
@@ -414,10 +414,10 @@ The following protocol fields exist in the packet format but have not been verif
 | Byte | Field | Notes |
 |------|-------|-------|
 | 4 | Uplight | The BLE chip accepts values 0-255 and echoes them, but the BTCR9 has no uplight fixture. May work on Fanimation models with an uplight. |
-| 8 | Fan Type | Purpose unknown. Always 0 in all observed responses. May select between AC/DC motor behavior on multi-mode receivers. |
+| 8 | Fan Type | Motor class: `0` on the tested AC fan, `2` on a community-tested DC fan. Appears to gate electronic reverse (DC only) — see [Direction](#8-direction). |
 | — | Timer range >360 | The FanSync app limits the timer to 360 minutes (6 hours). Values above 360 have not been tested. |
 | — | OAD Service | The TI OAD (Over-the-Air Download) firmware update service is present but has not been tested. Do not interact with it unless you know what you are doing. |
 
 ---
 
-*This protocol was reverse-engineered from the [SimpleFanController](https://github.com/toddhutch/SimpleFanController) Java/TinyB project (targeting DC fans) and verified against BTCR9 AC motor hardware using Python/bleak diagnostic scripts. All findings are based on empirical testing — no official Fanimation documentation was used.*
+*This protocol was reverse-engineered from the [SimpleFanController](https://github.com/toddhutch/SimpleFanController) Java/TinyB project (targeting DC fans) and verified against BTCR9 AC motor hardware — plus community DC-motor testing (#4) — using Python/bleak diagnostic scripts. All findings are based on empirical testing; no official Fanimation documentation was used.*

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -12,20 +12,30 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.components.fan import DIRECTION_FORWARD, DIRECTION_REVERSE, FanEntityFeature
 
 from custom_components.fanimation.const import (
     CONF_DEFAULT_SPEED,
     CONF_SPEED_COUNT,
+    CONF_SUPPORTS_REVERSE,
     DEFAULT_SPEED_LAST_USED,
+    DIR_FORWARD,
+    DIR_REVERSE,
     SPEED_HIGH,
     SPEED_LOW,
     SPEED_MED,
+    fan_type_supports_reverse,
     speed_for_preset,
 )
 from custom_components.fanimation.device import FanimationState
 
 
-def _make_fan(default_speed: str = DEFAULT_SPEED_LAST_USED, speed_count: int = 3):
+def _make_fan(
+    default_speed: str = DEFAULT_SPEED_LAST_USED,
+    speed_count: int = 3,
+    fan_type: int = 0,
+    supports_reverse: bool | None = None,
+):
     """Create a FanimationFan with mocked coordinator and entry for unit testing.
 
     ``async_set_state`` echoes the requested speed back as a ``FanimationState`` so
@@ -33,11 +43,19 @@ def _make_fan(default_speed: str = DEFAULT_SPEED_LAST_USED, speed_count: int = 3
     behaves as it would against real hardware that accepts the command. Tests that
     need to simulate firmware rejection or comm failure should override the mock
     with their own ``return_value``.
+
+    ``fan_type`` seeds the coordinator state (0 = AC, 2 = DC) so the entity's
+    reverse auto-detection can be exercised; ``supports_reverse`` (when not None)
+    sets the options override.
     """
     from custom_components.fanimation.fan import FanimationFan
 
     async def _echo_state(speed: int | None = None, **_kwargs: Any) -> FanimationState:
         return FanimationState(speed=speed if speed is not None else 0)
+
+    options: dict[str, Any] = {CONF_DEFAULT_SPEED: default_speed}
+    if supports_reverse is not None:
+        options[CONF_SUPPORTS_REVERSE] = supports_reverse
 
     mock_coordinator = MagicMock()
     mock_coordinator.device = MagicMock()
@@ -45,15 +63,15 @@ def _make_fan(default_speed: str = DEFAULT_SPEED_LAST_USED, speed_count: int = 3
     mock_coordinator.device.name = "Test Fan"
     mock_coordinator.device.async_set_state = AsyncMock(side_effect=_echo_state)
     mock_coordinator.async_start_fast_poll = AsyncMock()
-    mock_coordinator.data = FanimationState(speed=0)
+    mock_coordinator.data = FanimationState(speed=0, fan_type=fan_type)
     mock_coordinator.connection_failures = 0
     mock_coordinator.config_entry = MagicMock()
-    mock_coordinator.config_entry.options = {CONF_DEFAULT_SPEED: default_speed}
+    mock_coordinator.config_entry.options = dict(options)
     mock_coordinator.config_entry.entry_id = "test_entry"
 
     mock_entry = MagicMock()
     mock_entry.entry_id = "test_entry"
-    mock_entry.options = {CONF_DEFAULT_SPEED: default_speed}
+    mock_entry.options = dict(options)
     mock_entry.data = {CONF_SPEED_COUNT: speed_count}
 
     fan = FanimationFan(mock_coordinator, mock_entry)
@@ -264,3 +282,61 @@ class TestLastSpeedBookkeeping:
 
         # Still SPEED_MED so a subsequent "Last Used" turn-on goes back to medium.
         assert fan._last_speed == SPEED_MED
+
+
+class TestFanTypeReverseDetection:
+    """The reverse heuristic: only the confirmed DC fan_type (2) is reversible."""
+
+    @pytest.mark.parametrize(("fan_type", "expected"), [(2, True), (0, False), (1, False), (3, False)])
+    def test_helper(self, fan_type: int, expected: bool) -> None:
+        assert fan_type_supports_reverse(fan_type) is expected
+
+
+class TestIssue4Direction:
+    """Issue #4: opt-in reverse direction, auto-defaulting ON only for DC fans.
+
+    AC fans (fan_type 0) hide the control; DC fans (fan_type 2) show it by
+    default; the options toggle overrides either way. Reverse is instant — the
+    hardware probe confirmed DC fans reverse while stopped or spinning.
+    """
+
+    def test_direction_hidden_for_ac_fan(self) -> None:
+        fan, _ = _make_fan(fan_type=0)
+        assert not (fan.supported_features & FanEntityFeature.DIRECTION)
+
+    def test_direction_auto_shown_for_dc_fan(self) -> None:
+        fan, _ = _make_fan(fan_type=2)
+        assert fan.supported_features & FanEntityFeature.DIRECTION
+
+    def test_option_forces_on_for_undetected_fan(self) -> None:
+        fan, _ = _make_fan(fan_type=0, supports_reverse=True)
+        assert fan.supported_features & FanEntityFeature.DIRECTION
+
+    def test_option_forces_off_for_detected_fan(self) -> None:
+        fan, _ = _make_fan(fan_type=2, supports_reverse=False)
+        assert not (fan.supported_features & FanEntityFeature.DIRECTION)
+
+    def test_current_direction_mapping(self) -> None:
+        fan, coord = _make_fan(fan_type=2)
+        coord.data = FanimationState(speed=1, direction=DIR_REVERSE, fan_type=2)
+        assert fan.current_direction == DIRECTION_REVERSE
+        coord.data = FanimationState(speed=1, direction=DIR_FORWARD, fan_type=2)
+        assert fan.current_direction == DIRECTION_FORWARD
+
+    def test_current_direction_none_without_data(self) -> None:
+        fan, coord = _make_fan(fan_type=2)
+        coord.data = None
+        assert fan.current_direction is None
+
+    @pytest.mark.asyncio
+    async def test_set_direction_reverse_sends_command(self) -> None:
+        fan, coord = _make_fan(fan_type=2)
+        await fan.async_set_direction(DIRECTION_REVERSE)
+        coord.device.async_set_state.assert_called_once_with(direction=DIR_REVERSE)
+        coord.async_start_fast_poll.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_set_direction_forward_sends_command(self) -> None:
+        fan, coord = _make_fan(fan_type=2)
+        await fan.async_set_direction(DIRECTION_FORWARD)
+        coord.device.async_set_state.assert_called_once_with(direction=DIR_FORWARD)


### PR DESCRIPTION
## Summary

Restores a forward/reverse control — but only for fans that actually support electronic reverse. Direction was removed wholesale in 034c302 because it had no physical effect on the maintainer's AC motor. Hardware probing since then showed the `fan_type` byte (packet byte[8]) discriminates motor class: **AC reports 0** (direction byte accepted but inert) and **DC reports 2** (electronic reverse works, instantly, and reads back in byte[3]). @markjandejong confirmed DC reverse on real hardware — see #4 (now closed).

## How it works

- **Auto-detection:** `fan_type == 2` (`REVERSIBLE_FAN_TYPE`) → the fan exposes `FanEntityFeature.DIRECTION`. AC (0) and any not-yet-seen type default to no control.
- **Opt-in override:** a per-fan **Change direction** options toggle (`CONF_SUPPORTS_REVERSE`) defaults from the detected type but lets the user force it on/off. The integration reloads on options change, so the entity is re-created with the correct feature set.
- **Instant reverse:** `async_set_direction` just sends the new direction and fast-polls — no stop-and-wait sequence (the probe confirmed DC reverses whether stopped or spinning).
- **`current_direction`** is read from the verified device state (byte[3]), not the requested value.
- **AC unchanged:** `device.async_set_state` regains a `direction` parameter, but AC callers omit it, so the direction byte stays preserved exactly as before — AC behaviour is identical to having no control.

## Docs

- **README** updated within the new structure (rebased onto the restructure in 073e7bd): What Works direction row, the Compatibility direction bullet, and a new **Change direction** option in the Options list.
- **Protocol reference** updated with the AC=0 / DC=2 `fan_type` findings (byte[8] table, Direction section, gotchas).

## Tests

`tests/test_fan.py` extended (+84 lines) covering the direction feature.

## Verification

Confirmed on real DC hardware by @markjandejong (#4). AC behaviour unchanged by construction (direction byte preserved when no caller sets it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)