### PR TITLE
Platinum foundation: reconfiguration-flow, strict-typing, test coverage

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,31 @@
+name: Strict typing
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  mypy:
+    name: mypy --strict
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install -r requirements_test.txt
+
+      - name: Type-check (strict)
+        run: python3 -m mypy custom_components/fanimation

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
           python3 -m pip install -r requirements_test.txt
 
       - name: Run tests
-        run: python3 -m pytest tests/ -v
+        run: python3 -m pytest tests/ -v --cov=custom_components/fanimation --cov-report=term-missing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
           python3 -m pip install -r requirements_test.txt
 
       - name: Run tests
-        run: python3 -m pytest tests/ -v --cov=custom_components/fanimation --cov-report=term-missing --cov-fail-under=95
+        run: python3 -m pytest tests/ -v --cov=custom_components/fanimation --cov-report=term-missing --cov-fail-under=100

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
           python3 -m pip install -r requirements_test.txt
 
       - name: Run tests
-        run: python3 -m pytest tests/ -v --cov=custom_components/fanimation --cov-report=term-missing
+        run: python3 -m pytest tests/ -v --cov=custom_components/fanimation --cov-report=term-missing --cov-fail-under=95

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ If your Fanimation Bluetooth fan works — or doesn't — [open an issue](https:
 - **Finding your MAC address:** use any BLE scanner app (nRF Connect, LightBlue) and look for a device named `CeilingFan`. Colon, dash, or no-separator formats are all accepted.
 - **Entities go grey / "unavailable"?** BLE polling failed repeatedly. Move the fan closer to an adapter/proxy, or raise the **Unavailable threshold** in the integration's options.
 - **State seems to lag the physical remote.** The RF remote is independent of Bluetooth; the integration polls and reconciles state, so remote changes appear after the next poll rather than instantly.
+- **Sleep timer won't set / immediately reads 0?** The fan must be *running* before you set a timer — the BTCR9 controller silently ignores a timer set while the fan is off. Turn the fan on first, then set the minutes.
 - **I have a Fanimation *WiFi* fan.** This integration is Bluetooth-only and cannot control WiFi fans — see the note at the top.
 
 ## For Developers

--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ Per-fan options are configurable via **Settings → Devices → Configure** ([sc
 - **Disconnect notification** — persistent alert on first BLE failure
 - **Unavailable threshold** — how many poll failures before entities go grey
 
+## Use cases
+
+Bringing the fan into Home Assistant turns a remote-only ceiling fan into something you can automate, schedule, and combine with the rest of your home:
+
+- **Replace the remote.** Control speed, the downlight, and the sleep timer from any dashboard, your phone, or a wall tablet — no hunting for the RF remote.
+- **Temperature-reactive comfort.** Pair the fan with a thermostat or temperature sensor so it speeds up when a room warms and idles when it cools.
+- **Presence and away logic.** Turn the fan off when everyone leaves and resume it when someone gets home, or keep it on low while you're away to keep air moving.
+- **Schedules and sleep.** Drop to low at bedtime and arm the built-in sleep timer so the fan and light switch themselves off after you doze off; spin back up before you wake.
+- **Voice control.** It's a standard `fan` entity, so "turn off the bedroom fan" or "set the bedroom fan to 50%" works through Home Assistant Assist or any linked Alexa / Google / Siri assistant.
+- **One dashboard for every fan.** Group several Fanimation fans alongside your lights and climate on a single view instead of juggling one remote per room.
+
+Ready-to-adapt YAML for several of these is in [Example automations](#example-automations).
+
 ## What Works
 
 The BTCR9 BLE protocol has been reverse-engineered and verified on real AC hardware (DC fans community-tested):
@@ -104,6 +117,74 @@ This integration talks to the fan's **Bluetooth receiver**, so it should work wi
 - **Fanimation Odyn 84"** DC fan with TR305 FanSync remote (32 speeds) — community-tested in 1.2.0 by @JesusSanchezLopez, across 4 AC and DC fans ([Issue #1](https://github.com/sumgup0/FanimationHA-AC-BT/issues/1))
 
 If your Fanimation Bluetooth fan works — or doesn't — [open an issue](https://github.com/sumgup0/FanimationHA-AC-BT/issues) with the model name and speed count.
+
+## Example automations
+
+These examples use a fan named **Living Room Fan**; change the entity IDs to match yours. The three entities all live under the one fan device: the fan (`fan.living_room_fan`), its downlight (`light.living_room_fan_downlight`), and the sleep timer (`number.living_room_fan_sleep_timer`).
+
+**Speed up when the room gets warm** — pair with any temperature sensor:
+
+```yaml
+automation:
+  - alias: "Living room fan follows temperature"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.living_room_temperature
+        above: 25          # °C
+    action:
+      - service: fan.set_percentage
+        target:
+          entity_id: fan.living_room_fan
+        data:
+          percentage: 100
+```
+
+**Turn the fan off when everyone leaves:**
+
+```yaml
+automation:
+  - alias: "Fan off when away"
+    trigger:
+      - platform: state
+        entity_id: group.family
+        to: "not_home"
+    action:
+      - service: fan.turn_off
+        target:
+          entity_id: fan.living_room_fan
+```
+
+**Wind down at bedtime with the sleep timer** — it turns the fan *and* light off when it expires:
+
+```yaml
+automation:
+  - alias: "Bedroom fan sleep timer at 11 PM"
+    trigger:
+      - platform: time
+        at: "23:00:00"
+    action:
+      - service: fan.set_percentage      # the timer is ignored unless the fan is running
+        target:
+          entity_id: fan.bedroom_fan
+        data:
+          percentage: 33
+      - service: number.set_value
+        target:
+          entity_id: number.bedroom_fan_sleep_timer
+        data:
+          value: 60                      # minutes
+```
+
+The bedtime example sets a low speed *before* arming the timer on purpose: the BTCR9 silently ignores a timer set while the fan is off (see [Troubleshooting](#troubleshooting)).
+
+## How Home Assistant stays in sync
+
+This is a **local-polling** integration (`iot_class: local_polling`) — no cloud, no push. Home Assistant holds a Bluetooth connection to the fan and reads its state with a `GET_STATUS` poll on a schedule:
+
+- **Idle polling — every 5 minutes.** Between commands the integration polls slowly to keep Bluetooth traffic low.
+- **Fast burst after a command — ~1 second, three times.** When you change speed, brightness, direction, or the timer, it drops to a 1-second poll for three cycles so the dashboard confirms the new state almost instantly, then returns to the 5-minute cadence.
+- **No push updates, and the RF remote is independent of Bluetooth.** The BTCR9 doesn't push state changes on its own, so a change made with the physical remote is only reflected on the next poll — up to ~5 minutes later. Every command Home Assistant sends reads the live state first (read-before-write), so remote changes are never clobbered.
+- **The poll interval is fixed,** but the **Unavailable threshold** option controls how many consecutive failed polls (each ≈ 5 minutes) are tolerated before a fan's entities go grey.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ This integration is in the **HACS default store**, so no custom repository is ne
 2. Restart Home Assistant.
 3. Add the integration via **Settings → Devices & Services**.
 
+## Removing the integration
+
+1. In Home Assistant, go to **Settings → Devices & Services**.
+2. Find the **Fanimation BLE Ceiling Fan** entry, open its three-dot menu, and choose **Delete**. Home Assistant unloads the integration — stopping Bluetooth polling and disconnecting from the fan — and removes its device and entities automatically.
+3. *(Optional)* To remove the code as well:
+   - **HACS:** open **HACS → Fanimation BLE Ceiling Fan**, three-dot menu → **Remove**, then restart Home Assistant.
+   - **Manual install:** delete the `custom_components/fanimation/` folder and restart Home Assistant.
+
+Everything stays local — no cloud account, no data stored outside Home Assistant — so deleting the entry leaves nothing behind online or on the fan. The fan continues to work with its physical RF remote.
+
 ## Compatibility
 
 This integration talks to the fan's **Bluetooth receiver**, so it should work with any Fanimation ceiling fan that uses a **BTCR9-class FanSync Bluetooth receiver** — regardless of the specific fan model, motor type, or speed count. The hardware listed below is what has been **tested**; treat it as confirmed examples, not an exhaustive list.

--- a/custom_components/fanimation/config_flow.py
+++ b/custom_components/fanimation/config_flow.py
@@ -54,6 +54,19 @@ SERVICE_UUID = "0000e000-0000-1000-8000-00805f9b34fb"
 _MAC_RE = re.compile(r"^([0-9a-f]{2}:){5}[0-9a-f]{2}$")
 
 
+def _normalize_mac(raw: str) -> str | None:
+    """Normalise user MAC input to canonical uppercase colon form, or None if invalid.
+
+    Accepts colon / dash / dot / bare-hex via ``format_mac``; validates the result
+    against ``_MAC_RE`` before upper-casing. Shared by ``async_step_user`` and
+    ``async_step_reconfigure`` so the validation lives in one place.
+    """
+    normalized = format_mac(raw.strip())
+    if not _MAC_RE.match(normalized):
+        return None
+    return normalized.upper()
+
+
 def _speed_count_field() -> vol.All:
     """Voluptuous validator for the speed-count form field.
 
@@ -197,11 +210,10 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            normalized = format_mac(user_input[CONF_MAC].strip())
-            if not _MAC_RE.match(normalized):
+            mac = _normalize_mac(user_input[CONF_MAC])
+            if mac is None:
                 errors[CONF_MAC] = "invalid_mac"
             else:
-                mac = normalized.upper()
                 name = user_input[CONF_NAME]
 
                 # Set unique ID to prevent duplicates

--- a/custom_components/fanimation/config_flow.py
+++ b/custom_components/fanimation/config_flow.py
@@ -246,6 +246,48 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Change the MAC / name of an existing entry without re-adding it.
+
+        speed_count is intentionally not here — it is editable in the options flow.
+        The MAC may change (fix a typo / replaced receiver); we re-validate the new
+        address and block pointing at a fan that is already configured elsewhere.
+        """
+        reconfigure_entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            mac = _normalize_mac(user_input[CONF_MAC])
+            if mac is None:
+                errors[CONF_MAC] = "invalid_mac"
+            else:
+                name = user_input[CONF_NAME]
+                if mac != reconfigure_entry.unique_id:
+                    # MAC changed: re-key the entry and re-validate the new device.
+                    await self.async_set_unique_id(mac)
+                    self._abort_if_unique_id_configured()
+                    if not await self._async_validate_device(mac):
+                        errors["base"] = "cannot_connect"
+                if not errors:
+                    return self.async_update_reload_and_abort(
+                        reconfigure_entry,
+                        unique_id=mac,
+                        title=name,
+                        data_updates={CONF_MAC: mac, CONF_NAME: name},
+                    )
+
+        defaults = user_input or reconfigure_entry.data
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_MAC, default=defaults[CONF_MAC]): str,
+                    vol.Required(CONF_NAME, default=defaults[CONF_NAME]): str,
+                }
+            ),
+            errors=errors,
+        )
+
 
 class FanimationOptionsFlow(OptionsFlowWithConfigEntry):
     """Handle options for Fanimation BLE."""

--- a/custom_components/fanimation/config_flow.py
+++ b/custom_components/fanimation/config_flow.py
@@ -103,8 +103,9 @@ class FanimationConfigFlow(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize the config flow."""
         self._discovery_info: BluetoothServiceInfoBleak | None = None
-        self._mac: str | None = None
-        self._discovered_name: str | None = None
+        # Populated during Bluetooth discovery before async_step_bluetooth_confirm; "" until then.
+        self._mac: str = ""
+        self._discovered_name: str = ""
 
     async def _async_validate_device(self, mac: str) -> bool:
         """Connect to the fan and verify expected GATT characteristics exist.

--- a/custom_components/fanimation/coordinator.py
+++ b/custom_components/fanimation/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -38,13 +39,15 @@ class FanimationCoordinator(DataUpdateCoordinator[FanimationState]):
         self._fast_poll_remaining = 0
         self._connection_failures = 0
         self._notification_active = False
+        # Gate the "unreachable" warning so it logs once on loss, not every poll.
+        self._unavailable_logged = False
 
     @property
     def connection_failures(self) -> int:
         """Return the number of consecutive connection failures."""
         return self._connection_failures
 
-    def _get_option(self, key: str, default):
+    def _get_option(self, key: str, default: Any) -> Any:
         """Read an option from the config entry, with fallback default."""
         if self.config_entry and self.config_entry.options:
             return self.config_entry.options.get(key, default)
@@ -81,12 +84,21 @@ class FanimationCoordinator(DataUpdateCoordinator[FanimationState]):
             return await self._async_handle_failure(f"No response from {self.device.name}")
 
         # --- Success ---
-        was_failing = self._connection_failures > 0
+        failures = self._connection_failures
         self._connection_failures = 0
 
-        # Dismiss notification on recovery
-        if was_failing:
+        # Recovery housekeeping. Log restoration once, but only if we logged the
+        # loss ourselves (soft-unavailable path). Once we've escalated to
+        # UpdateFailed, HA's coordinator owns the "recovered" message.
+        if failures > 0:
             await self._async_dismiss_notification()
+            if self._unavailable_logged:
+                LOGGER.info(
+                    "%s is reachable again after %d failed poll(s)",
+                    self.device.name,
+                    failures,
+                )
+                self._unavailable_logged = False
 
         # Manage fast/slow polling transition
         if self._fast_poll_remaining > 0:
@@ -116,17 +128,26 @@ class FanimationCoordinator(DataUpdateCoordinator[FanimationState]):
         threshold = self._get_option(CONF_UNAVAILABLE_THRESHOLD, DEFAULT_UNAVAILABLE_THRESHOLD)
 
         if threshold > 0 and self._connection_failures >= threshold:
-            # Hard unavailable — dismiss notification (HA shows unavailable natively)
+            # Hard unavailable — dismiss notification (HA shows unavailable natively).
+            # Hand logging off to HA's coordinator, which logs the UpdateFailed
+            # once and the recovery once via last_update_success.
             await self._async_dismiss_notification()
+            self._unavailable_logged = False
             raise UpdateFailed(f"{error_msg} after {self._connection_failures} attempts")
 
         if self.data is not None:
-            # Soft unavailable — return stale data, entities stay available
-            LOGGER.warning(
-                "%s (%d failures) — returning last known state",
-                error_msg,
-                self._connection_failures,
-            )
+            # Soft unavailable — return stale data, entities stay available.
+            # Warn once on the transition, then drop to debug so a fan that is
+            # unreachable for hours doesn't fill the log with one line per poll.
+            if not self._unavailable_logged:
+                LOGGER.warning("%s — returning last known state; will keep retrying", error_msg)
+                self._unavailable_logged = True
+            else:
+                LOGGER.debug(
+                    "%s (%d failures) — still returning last known state",
+                    error_msg,
+                    self._connection_failures,
+                )
             return self.data
 
         # No prior state at all — must raise regardless of threshold

--- a/custom_components/fanimation/device.py
+++ b/custom_components/fanimation/device.py
@@ -153,7 +153,10 @@ class FanimationDevice:
         self._notify_event.clear()
         self._last_notification = None
 
-        await self._client.write_gatt_char(CHAR_WRITE, packet)
+        client = self._client
+        if client is None:
+            raise ConnectionError(f"Fan {self._name} ({self._mac}) is not connected")
+        await client.write_gatt_char(CHAR_WRITE, packet)
 
         try:
             await asyncio.wait_for(self._notify_event.wait(), timeout=timeout)

--- a/custom_components/fanimation/diagnostics.py
+++ b/custom_components/fanimation/diagnostics.py
@@ -1,0 +1,56 @@
+"""Diagnostics support for the Fanimation BLE integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_MAC
+from homeassistant.core import HomeAssistant
+
+from . import FanimationConfigEntry
+
+# The MAC is the only identifying value worth hiding from shared diagnostics.
+TO_REDACT = {CONF_MAC}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: FanimationConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry.
+
+    The decoded protocol state — including the ``direction`` and ``fan_type``
+    bytes — is included verbatim. It carries no personal data and is exactly
+    what's needed to triage behaviour reports such as Issue #4 (DC-fan
+    direction), so it is deliberately not redacted.
+    """
+    coordinator = entry.runtime_data
+    state = coordinator.data
+
+    return {
+        "entry": {
+            "title": entry.title,
+            "data": async_redact_data(dict(entry.data), TO_REDACT),
+            "options": dict(entry.options),
+        },
+        "coordinator": {
+            "last_update_success": coordinator.last_update_success,
+            "update_interval_seconds": (
+                coordinator.update_interval.total_seconds() if coordinator.update_interval else None
+            ),
+            "connection_failures": coordinator.connection_failures,
+        },
+        "state": (
+            {
+                "speed": state.speed,
+                "direction": state.direction,
+                "uplight": state.uplight,
+                "downlight": state.downlight,
+                "timer_minutes": state.timer_minutes,
+                "fan_type": state.fan_type,
+            }
+            if state is not None
+            else None
+        ),
+    }

--- a/custom_components/fanimation/fan.py
+++ b/custom_components/fanimation/fan.py
@@ -35,6 +35,10 @@ from .const import (
 from .coordinator import FanimationCoordinator
 from .entity import FanimationEntity
 
+# Serialise commands: every BLE write goes through the shared device-level lock,
+# so one in-flight command at a time matches HA's BLE convention.
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/fanimation/fan.py
+++ b/custom_components/fanimation/fan.py
@@ -11,7 +11,8 @@ from homeassistant.components.fan import (
     FanEntity,
     FanEntityFeature,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.percentage import (
     percentage_to_ranged_value,
@@ -27,6 +28,7 @@ from .const import (
     DEFAULT_SPEED_LAST_USED,
     DIR_FORWARD,
     DIR_REVERSE,
+    DOMAIN,
     SPEED_LOW,
     SPEED_OFF,
     fan_type_supports_reverse,
@@ -62,6 +64,7 @@ class FanimationFan(FanimationEntity, FanEntity):
     ) -> None:
         """Initialize the fan entity."""
         super().__init__(coordinator, entry.entry_id)
+        self._entry_id = entry.entry_id
         self._attr_unique_id = f"{coordinator.device.mac}_fan"
         # Speed count: options-flow value wins, then install-time data, then default.
         self._speed_count = entry.options.get(
@@ -81,6 +84,62 @@ class FanimationFan(FanimationEntity, FanEntity):
         if self._supports_reverse:
             features |= FanEntityFeature.DIRECTION
         self._attr_supported_features = features
+
+    @property
+    def _speed_count_issue_id(self) -> str:
+        """Deterministic repair-issue id for this fan's speed-count mismatch."""
+        return f"speed_count_out_of_range_{self._entry_id}"
+
+    async def async_added_to_hass(self) -> None:
+        """Register the coordinator listener and evaluate the speed-count issue once."""
+        await super().async_added_to_hass()
+        self._evaluate_speed_count_issue()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Clear any open speed-count repair issue when the entity is removed.
+
+        Covers integration removal: the in-range self-heal only runs while the
+        entity is alive, so without this a stale issue would linger until the
+        next restart (the issue is non-persistent).
+        """
+        ir.async_delete_issue(self.hass, DOMAIN, self._speed_count_issue_id)
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Re-evaluate the speed-count issue on each poll, then write entity state."""
+        self._evaluate_speed_count_issue()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _evaluate_speed_count_issue(self) -> None:
+        """Raise or clear a repair issue when the fan reports a speed above speed_count.
+
+        A hardware speed greater than the configured ``speed_count`` (e.g. a
+        32-speed DC fan left at the default 3) is a user-fixable misconfiguration:
+        ``percentage`` clamps the slider to the configured max, so higher speeds
+        set by the RF remote read as the top step. The repair issue points the
+        user at the options flow to raise the count, and clears automatically
+        once the reported speed is back in range — including after the user fixes
+        the option and the entry reloads.
+        """
+        data = self.coordinator.data
+        if data is not None and data.speed > self._speed_count:
+            ir.async_create_issue(
+                self.hass,
+                DOMAIN,
+                self._speed_count_issue_id,
+                is_fixable=False,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="speed_count_out_of_range",
+                translation_placeholders={
+                    "name": self.coordinator.device.name,
+                    "reported_speed": str(data.speed),
+                    "speed_count": str(self._speed_count),
+                },
+            )
+        else:
+            ir.async_delete_issue(self.hass, DOMAIN, self._speed_count_issue_id)
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/fanimation/icons.json
+++ b/custom_components/fanimation/icons.json
@@ -1,0 +1,9 @@
+{
+  "entity": {
+    "number": {
+      "sleep_timer": {
+        "default": "mdi:timer-outline"
+      }
+    }
+  }
+}

--- a/custom_components/fanimation/light.py
+++ b/custom_components/fanimation/light.py
@@ -23,6 +23,10 @@ from .entity import FanimationEntity
 if TYPE_CHECKING:
     from .coordinator import FanimationCoordinator
 
+# Serialise commands: every BLE write goes through the shared device-level lock,
+# so one in-flight command at a time matches HA's BLE convention.
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/fanimation/light.py
+++ b/custom_components/fanimation/light.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.light import (
-    ATTR_BRIGHTNESS,
-    ColorMode,
-    LightEntity,
-)
+from homeassistant.components.light import ATTR_BRIGHTNESS, LightEntity
+from homeassistant.components.light.const import ColorMode
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -42,7 +39,6 @@ class FanimationLight(FanimationEntity, LightEntity):
     """Fanimation downlight entity."""
 
     _attr_color_mode = ColorMode.BRIGHTNESS
-    _attr_supported_color_modes: ClassVar[set[ColorMode]] = {ColorMode.BRIGHTNESS}
     _attr_translation_key = "downlight"
 
     def __init__(
@@ -52,6 +48,9 @@ class FanimationLight(FanimationEntity, LightEntity):
     ) -> None:
         """Initialize the light entity."""
         super().__init__(coordinator, entry_id)
+        # Instance (not class) attribute: overriding LightEntity's instance var with a
+        # ClassVar trips mypy [misc], and a bare class-level mutable set trips ruff RUF012.
+        self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
         self._attr_unique_id = f"{coordinator.device.mac}_light"
         self._last_brightness = DOWNLIGHT_MAX  # default for turn_on without brightness
 

--- a/custom_components/fanimation/manifest.json
+++ b/custom_components/fanimation/manifest.json
@@ -10,6 +10,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/sumgup0/FanimationHA-AC-BT/issues",
   "loggers": ["custom_components.fanimation"],
+  "quality_scale": "platinum",
   "requirements": ["bleak-retry-connector>=4.0.0"],
   "version": "1.3.0"
 }

--- a/custom_components/fanimation/number.py
+++ b/custom_components/fanimation/number.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -16,6 +16,10 @@ from .entity import FanimationEntity
 
 if TYPE_CHECKING:
     from .coordinator import FanimationCoordinator
+
+# Serialise commands: every BLE write goes through the shared device-level lock,
+# so one in-flight command at a time matches HA's BLE convention.
+PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(
@@ -31,7 +35,7 @@ async def async_setup_entry(
 class FanimationTimer(FanimationEntity, NumberEntity):
     """Fanimation sleep timer entity."""
 
-    _attr_icon = "mdi:timer-outline"
+    _attr_device_class = NumberDeviceClass.DURATION
     _attr_mode = NumberMode.SLIDER
     _attr_native_min_value = TIMER_MIN
     _attr_native_max_value = TIMER_MAX

--- a/custom_components/fanimation/number.py
+++ b/custom_components/fanimation/number.py
@@ -11,7 +11,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import FanimationConfigEntry
-from .const import TIMER_MAX, TIMER_MIN
+from .const import DOMAIN, TIMER_MAX, TIMER_MIN
 from .entity import FanimationEntity
 
 if TYPE_CHECKING:
@@ -35,6 +35,9 @@ async def async_setup_entry(
 class FanimationTimer(FanimationEntity, NumberEntity):
     """Fanimation sleep timer entity."""
 
+    # No entity_category: this is a primary operational control with live state
+    # (remaining minutes) that turns the fan + light off on expiry — not a static
+    # CONFIG knob or a read-only DIAGNOSTIC readout.
     _attr_device_class = NumberDeviceClass.DURATION
     _attr_mode = NumberMode.SLIDER
     _attr_native_min_value = TIMER_MIN
@@ -77,7 +80,8 @@ class FanimationTimer(FanimationEntity, NumberEntity):
         """
         if int(value) > 0 and self.coordinator.data and self.coordinator.data.speed == 0:
             raise HomeAssistantError(
-                "The sleep timer only works when the fan is running. Turn the fan on first, then set the timer."
+                translation_domain=DOMAIN,
+                translation_key="timer_requires_fan_on",
             )
         await self.coordinator.device.async_set_state(timer_minutes=int(value))
         await self.coordinator.async_start_fast_poll()

--- a/custom_components/fanimation/quality_scale.yaml
+++ b/custom_components/fanimation/quality_scale.yaml
@@ -1,14 +1,8 @@
-# Home Assistant Integration Quality Scale — progress tracker.
+# Home Assistant Integration Quality Scale — Fanimation BLE Ceiling Fan.
 #
-# STAGED IN docs/ ON PURPOSE. hassfest validates quality_scale.yaml when it
-# lives in the integration directory and fails CI if manifest.json declares a
-# tier whose rules are not all `done`/`exempt`. Until the tiers are green this
-# file is kept out of custom_components/fanimation/ so the Validate workflow
-# stays green.
-#
-# CAPSTONE STEP (per tier, once its rules are all done/exempt):
-#   1. git mv docs/quality_scale.yaml custom_components/fanimation/quality_scale.yaml
-#   2. add  "quality_scale": "<tier>"  to manifest.json
+# This integration targets Platinum; manifest.json declares
+# "quality_scale": "platinum". hassfest validates that every rule below is
+# `done` or `exempt`.
 #
 # Status values: done | todo | exempt
 # https://developers.home-assistant.io/docs/core/integration-quality-scale/
@@ -52,15 +46,20 @@ rules:
   reauthentication-flow:
     status: exempt
     comment: Local BLE device with no credentials or auth.
-  test-coverage: done  # 100% in CI (612/612 stmts, all modules incl. Linux-only config_flow/diagnostics); enforced by --cov-fail-under=100 in the Tests workflow.
+  test-coverage: done  # 100% in CI (all modules incl. Linux-only config_flow/diagnostics); enforced by --cov-fail-under=100 in the Tests workflow.
 
   # ------------------------------------------------------------------ Gold ---
   devices: done
   diagnostics: done
   discovery: done
   discovery-update-info:
-    status: todo
-    comment: Refresh device info from Bluetooth re-discovery.
+    status: exempt
+    comment: >
+      BLE transport: the device's Bluetooth MAC is its immutable unique_id, and
+      HA's Bluetooth manager always resolves the freshest connectable BLEDevice
+      on connect — there is no IP/network address to refresh. The BTCR9 exposes
+      no Device Information Service, so there is no firmware/serial to update on
+      re-discovery either (cf. victron_ble, idasen_desk, switchbot).
   docs-data-update: done  # README "How Home Assistant stays in sync" — local_polling, 5-min slow poll + 1s×3 fast burst, no push, RF-remote lag.
   docs-examples: done  # README "Example automations" — temperature, presence, and bedtime-sleep-timer YAML.
   docs-known-limitations: done  # README documents AC-vs-DC direction and the timer-needs-fan-running rule

--- a/custom_components/fanimation/strings.json
+++ b/custom_components/fanimation/strings.json
@@ -94,5 +94,10 @@
         "name": "Sleep timer"
       }
     }
+  },
+  "exceptions": {
+    "timer_requires_fan_on": {
+      "message": "The sleep timer only works when the fan is running. Turn the fan on first, then set the timer."
+    }
   }
 }

--- a/custom_components/fanimation/strings.json
+++ b/custom_components/fanimation/strings.json
@@ -111,5 +111,11 @@
     "timer_requires_fan_on": {
       "message": "The sleep timer only works when the fan is running. Turn the fan on first, then set the timer."
     }
+  },
+  "issues": {
+    "speed_count_out_of_range": {
+      "title": "{name}: fan speed exceeds the configured speed count",
+      "description": "{name} reported speed {reported_speed}, but it is set to only {speed_count} speeds, so Home Assistant is clamping the speed slider to its maximum. Speeds set above this with the RF remote will read as the top step.\n\nTo fix this, open the integration options (Settings → Devices & Services → Fanimation BLE Ceiling Fan → Configure) and set **Number of fan speeds** to match your fan's hardware. AC fans are usually 3; DC fans are commonly 6 or 32."
+    }
   }
 }

--- a/custom_components/fanimation/strings.json
+++ b/custom_components/fanimation/strings.json
@@ -23,6 +23,17 @@
         "data_description": {
           "speed_count": "Pick or type the number of speeds your fan supports. AC fans are usually 3; DC fans are commonly 6 or 32. You can change this later in the integration's options."
         }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Fanimation Ceiling Fan",
+        "description": "Update the Bluetooth address or name for this fan. The fan must be in range to change the address.",
+        "data": {
+          "mac": "MAC address",
+          "name": "Friendly name"
+        },
+        "data_description": {
+          "mac": "Find it with a BLE scanner app (look for a device named CeilingFan). Colon, dash, or no-separator formats all work."
+        }
       }
     },
     "error": {
@@ -33,7 +44,8 @@
     "abort": {
       "already_configured": "This fan is already configured.",
       "already_in_progress": "This fan is already being set up (it was auto-discovered). Finish or cancel that setup instead of adding it manually.",
-      "not_fanimation": "This device does not appear to be a Fanimation fan (expected GATT characteristics not found)."
+      "not_fanimation": "This device does not appear to be a Fanimation fan (expected GATT characteristics not found).",
+      "reconfigure_successful": "The fan was reconfigured successfully."
     }
   },
   "options": {

--- a/custom_components/fanimation/translations/en.json
+++ b/custom_components/fanimation/translations/en.json
@@ -94,5 +94,10 @@
         "name": "Sleep timer"
       }
     }
+  },
+  "exceptions": {
+    "timer_requires_fan_on": {
+      "message": "The sleep timer only works when the fan is running. Turn the fan on first, then set the timer."
+    }
   }
 }

--- a/custom_components/fanimation/translations/en.json
+++ b/custom_components/fanimation/translations/en.json
@@ -111,5 +111,11 @@
     "timer_requires_fan_on": {
       "message": "The sleep timer only works when the fan is running. Turn the fan on first, then set the timer."
     }
+  },
+  "issues": {
+    "speed_count_out_of_range": {
+      "title": "{name}: fan speed exceeds the configured speed count",
+      "description": "{name} reported speed {reported_speed}, but it is set to only {speed_count} speeds, so Home Assistant is clamping the speed slider to its maximum. Speeds set above this with the RF remote will read as the top step.\n\nTo fix this, open the integration options (Settings → Devices & Services → Fanimation BLE Ceiling Fan → Configure) and set **Number of fan speeds** to match your fan's hardware. AC fans are usually 3; DC fans are commonly 6 or 32."
+    }
   }
 }

--- a/custom_components/fanimation/translations/en.json
+++ b/custom_components/fanimation/translations/en.json
@@ -23,6 +23,17 @@
         "data_description": {
           "speed_count": "Pick or type the number of speeds your fan supports. AC fans are usually 3; DC fans are commonly 6 or 32. You can change this later in the integration's options."
         }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Fanimation Ceiling Fan",
+        "description": "Update the Bluetooth address or name for this fan. The fan must be in range to change the address.",
+        "data": {
+          "mac": "MAC address",
+          "name": "Friendly name"
+        },
+        "data_description": {
+          "mac": "Find it with a BLE scanner app (look for a device named CeilingFan). Colon, dash, or no-separator formats all work."
+        }
       }
     },
     "error": {
@@ -33,7 +44,8 @@
     "abort": {
       "already_configured": "This fan is already configured.",
       "already_in_progress": "This fan is already being set up (it was auto-discovered). Finish or cancel that setup instead of adding it manually.",
-      "not_fanimation": "This device does not appear to be a Fanimation fan (expected GATT characteristics not found)."
+      "not_fanimation": "This device does not appear to be a Fanimation fan (expected GATT characteristics not found).",
+      "reconfigure_successful": "The fan was reconfigured successfully."
     }
   },
   "options": {

--- a/docs/quality_scale.yaml
+++ b/docs/quality_scale.yaml
@@ -1,0 +1,117 @@
+# Home Assistant Integration Quality Scale — progress tracker.
+#
+# STAGED IN docs/ ON PURPOSE. hassfest validates quality_scale.yaml when it
+# lives in the integration directory and fails CI if manifest.json declares a
+# tier whose rules are not all `done`/`exempt`. Until the tiers are green this
+# file is kept out of custom_components/fanimation/ so the Validate workflow
+# stays green.
+#
+# CAPSTONE STEP (per tier, once its rules are all done/exempt):
+#   1. git mv docs/quality_scale.yaml custom_components/fanimation/quality_scale.yaml
+#   2. add  "quality_scale": "<tier>"  to manifest.json
+#
+# Status values: done | todo | exempt
+# https://developers.home-assistant.io/docs/core/integration-quality-scale/
+
+rules:
+  # ---------------------------------------------------------------- Bronze ---
+  action-setup:
+    status: exempt
+    comment: Provides entities only; registers no service actions.
+  appropriate-polling: done
+  brands:
+    status: exempt
+    comment: Custom (HACS) integration; brand assets are bundled, not in home-assistant/brands.
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: No service actions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done  # all Bronze rules now done/exempt
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # ---------------------------------------------------------------- Silver ---
+  action-exceptions: done
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: todo
+    comment: Document each options-flow parameter in user docs.
+  docs-installation-parameters:
+    status: todo
+    comment: Document the MAC / name / speed-count setup fields in user docs.
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates:
+    status: todo
+    comment: light + number done; fan platform's PARALLEL_UPDATES lands with the #4 fan work.
+  reauthentication-flow:
+    status: exempt
+    comment: Local BLE device with no credentials or auth.
+  test-coverage:
+    status: todo
+    comment: Measure and reach >95% across all modules.
+
+  # ------------------------------------------------------------------ Gold ---
+  devices: done
+  diagnostics: done
+  discovery: done
+  discovery-update-info:
+    status: todo
+    comment: Refresh device info from Bluetooth re-discovery.
+  docs-data-update:
+    status: todo
+  docs-examples:
+    status: todo
+  docs-known-limitations:
+    status: todo
+    comment: Document AC-vs-DC direction and the timer-needs-fan-running rule.
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting:
+    status: todo
+  docs-use-cases:
+    status: todo
+  dynamic-devices:
+    status: exempt
+    comment: One physical device per config entry.
+  entity-category:
+    status: todo
+    comment: Decision pending — sleep timer is an operational control (leaning no category); revisit whether EntityCategory.CONFIG fits.
+  entity-device-class: done
+  entity-disabled-by-default:
+    status: exempt
+    comment: All three entities are primary controls.
+  entity-translations: done
+  exception-translations:
+    status: todo
+    comment: Make the sleep-timer HomeAssistantError translatable.
+  icon-translations: done
+  reconfiguration-flow:
+    status: todo
+    comment: Add async_step_reconfigure to change MAC / name without re-adding.
+  repair-issues:
+    status: todo
+    comment: Raise a repair issue when speed_count is misconfigured.
+  stale-devices:
+    status: exempt
+    comment: One physical device per config entry.
+
+  # -------------------------------------------------------------- Platinum ---
+  async-dependency: done
+  inject-websession:
+    status: exempt
+    comment: BLE transport; there is no HTTP session to inject.
+  strict-typing:
+    status: todo
+    comment: py.typed and mypy config added; flow and fan modules still need full typing and a CI mypy job.

--- a/docs/quality_scale.yaml
+++ b/docs/quality_scale.yaml
@@ -84,9 +84,7 @@ rules:
   entity-translations: done
   exception-translations: done  # sleep-timer HomeAssistantError uses translation_key; transport ConnectionError/ValueError are internal, not user-facing
   icon-translations: done
-  reconfiguration-flow:
-    status: todo
-    comment: Add async_step_reconfigure to change MAC / name without re-adding.
+  reconfiguration-flow: done  # async_step_reconfigure (change MAC/name in place) + 6 TestReconfigure cases; pytest green in CI (PR #9).
   repair-issues:
     status: todo
     comment: Raise a repair issue when speed_count is misconfigured.

--- a/docs/quality_scale.yaml
+++ b/docs/quality_scale.yaml
@@ -54,7 +54,7 @@ rules:
     comment: Local BLE device with no credentials or auth.
   test-coverage:
     status: todo
-    comment: number.py now 100% (test_number.py). Real gaps remain in device.py (BLE I/O), __init__.py, light.py, entity.py; >95% is a separate effort (config_flow/diagnostics covered in CI only).
+    comment: Phase 1 done — entity.py/fan.py/light.py/device.py all 100% locally (number.py already 100%). Remaining gaps: coordinator.py + __init__.py, plus the CI --cov-fail-under gate; true >95% total is CI-only (config_flow/diagnostics read 0% locally).
 
   # ------------------------------------------------------------------ Gold ---
   devices: done

--- a/docs/quality_scale.yaml
+++ b/docs/quality_scale.yaml
@@ -83,9 +83,7 @@ rules:
   exception-translations: done  # sleep-timer HomeAssistantError uses translation_key; transport ConnectionError/ValueError are internal, not user-facing
   icon-translations: done
   reconfiguration-flow: done  # async_step_reconfigure (change MAC/name in place) + 6 TestReconfigure cases; pytest green in CI (PR #9).
-  repair-issues:
-    status: todo
-    comment: Raise a repair issue when speed_count is misconfigured.
+  repair-issues: done  # WARNING repair issue when a fan reports speed > configured speed_count (fan.py _evaluate_speed_count_issue); points user at the options flow, self-clears when back in range. Issue #1 follow-up.
   stale-devices:
     status: exempt
     comment: One physical device per config entry.

--- a/docs/quality_scale.yaml
+++ b/docs/quality_scale.yaml
@@ -97,6 +97,4 @@ rules:
   inject-websession:
     status: exempt
     comment: BLE transport; there is no HTTP session to inject.
-  strict-typing:
-    status: todo
-    comment: Code passes mypy --strict (0 errors, commit 89791a6); still needs a CI mypy job + mypy as a dev-dep, verified via the PR before marking done.
+  strict-typing: done  # mypy --strict clean (0 errors, 89791a6); CI mypy job (.github/workflows/mypy.yml) green in PR #9.

--- a/docs/quality_scale.yaml
+++ b/docs/quality_scale.yaml
@@ -52,9 +52,7 @@ rules:
   reauthentication-flow:
     status: exempt
     comment: Local BLE device with no credentials or auth.
-  test-coverage:
-    status: todo
-    comment: Phase 1 done — entity.py/fan.py/light.py/device.py all 100% locally (number.py already 100%). Remaining gaps: coordinator.py + __init__.py, plus the CI --cov-fail-under gate; true >95% total is CI-only (config_flow/diagnostics read 0% locally).
+  test-coverage: done  # 100% in CI (612/612 stmts, all modules incl. Linux-only config_flow/diagnostics); enforced by --cov-fail-under=100 in the Tests workflow.
 
   # ------------------------------------------------------------------ Gold ---
   devices: done

--- a/docs/quality_scale.yaml
+++ b/docs/quality_scale.yaml
@@ -101,4 +101,4 @@ rules:
     comment: BLE transport; there is no HTTP session to inject.
   strict-typing:
     status: todo
-    comment: py.typed and mypy config added; flow and fan modules still need full typing and a CI mypy job.
+    comment: Code passes mypy --strict (0 errors, commit 89791a6); still needs a CI mypy job + mypy as a dev-dep, verified via the PR before marking done.

--- a/docs/quality_scale.yaml
+++ b/docs/quality_scale.yaml
@@ -61,16 +61,13 @@ rules:
   discovery-update-info:
     status: todo
     comment: Refresh device info from Bluetooth re-discovery.
-  docs-data-update:
-    status: todo
-  docs-examples:
-    status: todo
+  docs-data-update: done  # README "How Home Assistant stays in sync" — local_polling, 5-min slow poll + 1s×3 fast burst, no push, RF-remote lag.
+  docs-examples: done  # README "Example automations" — temperature, presence, and bedtime-sleep-timer YAML.
   docs-known-limitations: done  # README documents AC-vs-DC direction and the timer-needs-fan-running rule
   docs-supported-devices: done
   docs-supported-functions: done
   docs-troubleshooting: done  # README "Troubleshooting" section
-  docs-use-cases:
-    status: todo
+  docs-use-cases: done  # README "Use cases" — why integrate + combine-with-other-devices (temperature, presence, voice, dashboards).
   dynamic-devices:
     status: exempt
     comment: One physical device per config entry.

--- a/docs/quality_scale.yaml
+++ b/docs/quality_scale.yaml
@@ -43,24 +43,18 @@ rules:
   # ---------------------------------------------------------------- Silver ---
   action-exceptions: done
   config-entry-unloading: done
-  docs-configuration-parameters:
-    status: todo
-    comment: Document each options-flow parameter in user docs.
-  docs-installation-parameters:
-    status: todo
-    comment: Document the MAC / name / speed-count setup fields in user docs.
+  docs-configuration-parameters: done  # README "Options" documents all six options-flow parameters
+  docs-installation-parameters: done  # README documents the MAC + speed-count setup fields (name field is self-evident)
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
-  parallel-updates:
-    status: todo
-    comment: light + number done; fan platform's PARALLEL_UPDATES lands with the #4 fan work.
+  parallel-updates: done  # all three platforms (fan, light, number) set PARALLEL_UPDATES = 1
   reauthentication-flow:
     status: exempt
     comment: Local BLE device with no credentials or auth.
   test-coverage:
     status: todo
-    comment: Measure and reach >95% across all modules.
+    comment: number.py now 100% (test_number.py). Real gaps remain in device.py (BLE I/O), __init__.py, light.py, entity.py; >95% is a separate effort (config_flow/diagnostics covered in CI only).
 
   # ------------------------------------------------------------------ Gold ---
   devices: done
@@ -73,29 +67,22 @@ rules:
     status: todo
   docs-examples:
     status: todo
-  docs-known-limitations:
-    status: todo
-    comment: Document AC-vs-DC direction and the timer-needs-fan-running rule.
+  docs-known-limitations: done  # README documents AC-vs-DC direction and the timer-needs-fan-running rule
   docs-supported-devices: done
   docs-supported-functions: done
-  docs-troubleshooting:
-    status: todo
+  docs-troubleshooting: done  # README "Troubleshooting" section
   docs-use-cases:
     status: todo
   dynamic-devices:
     status: exempt
     comment: One physical device per config entry.
-  entity-category:
-    status: todo
-    comment: Decision pending — sleep timer is an operational control (leaning no category); revisit whether EntityCategory.CONFIG fits.
+  entity-category: done  # No category: fan/light/timer are primary controls. The timer is operational with live state and triggers a primary action, so CONFIG/DIAGNOSTIC don't fit; config-like settings live in the options flow, not entities.
   entity-device-class: done
   entity-disabled-by-default:
     status: exempt
     comment: All three entities are primary controls.
   entity-translations: done
-  exception-translations:
-    status: todo
-    comment: Make the sleep-timer HomeAssistantError translatable.
+  exception-translations: done  # sleep-timer HomeAssistantError uses translation_key; transport ConnectionError/ValueError are internal, not user-facing
   icon-translations: done
   reconfiguration-flow:
     status: todo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,15 @@ ignore = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+
+[tool.mypy]
+# Foundation for the Platinum `strict-typing` rule. Run locally with:
+#   mypy custom_components/fanimation
+# A CI mypy job is added once every module — including the in-flux config flow
+# and fan platform (parked behind issues #4/#5) — type-checks clean under strict.
+python_version = "3.13"
+strict = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+disallow_untyped_defs = true
+exclude = "tests/"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-asyncio
+pytest-cov
 pytest-homeassistant-custom-component
 mypy

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-asyncio
 pytest-homeassistant-custom-component
+mypy

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -415,3 +415,113 @@ class TestDuplicatePrevention:
 
         assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "already_configured"
+
+
+# ---------------------------------------------------------------------------
+# Reconfiguration flow (change MAC / name)
+# ---------------------------------------------------------------------------
+
+OTHER_MAC = "AA:BB:CC:DD:EE:FF"
+_VALIDATE = "custom_components.fanimation.config_flow.FanimationConfigFlow._async_validate_device"
+_SETUP = "custom_components.fanimation.async_setup_entry"
+
+
+def _existing_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Add and return a configured fan entry for reconfigure tests."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_MAC.upper(),
+        data={CONF_MAC: TEST_MAC.upper(), CONF_NAME: TEST_NAME, CONF_SPEED_COUNT: 3},
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+class TestReconfigure:
+    """Tests for async_step_reconfigure (change MAC / name in place)."""
+
+    async def test_reconfigure_shows_form(self, hass: HomeAssistant) -> None:
+        entry = _existing_entry(hass)
+        result = await entry.start_reconfigure_flow(hass)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "reconfigure"
+
+    async def test_reconfigure_rename_only_skips_validation(self, hass: HomeAssistant) -> None:
+        entry = _existing_entry(hass)
+        result = await entry.start_reconfigure_flow(hass)
+
+        with (
+            patch(_VALIDATE, AsyncMock(return_value=True)) as mock_validate,
+            patch(_SETUP, return_value=True),
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_MAC: TEST_MAC.upper(), CONF_NAME: "Living Room Fan"},
+            )
+            await hass.async_block_till_done()
+
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "reconfigure_successful"
+        mock_validate.assert_not_called()
+        assert entry.data[CONF_NAME] == "Living Room Fan"
+        assert entry.data[CONF_MAC] == TEST_MAC.upper()
+        assert entry.data[CONF_SPEED_COUNT] == 3
+        assert entry.title == "Living Room Fan"
+
+    async def test_reconfigure_mac_change_validates_and_updates(self, hass: HomeAssistant) -> None:
+        entry = _existing_entry(hass)
+        result = await entry.start_reconfigure_flow(hass)
+
+        with (
+            patch(_VALIDATE, AsyncMock(return_value=True)) as mock_validate,
+            patch(_SETUP, return_value=True),
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_MAC: OTHER_MAC, CONF_NAME: TEST_NAME},
+            )
+            await hass.async_block_till_done()
+
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "reconfigure_successful"
+        mock_validate.assert_awaited_once()
+        assert entry.data[CONF_MAC] == OTHER_MAC
+        assert entry.unique_id == OTHER_MAC
+
+    async def test_reconfigure_invalid_mac_shows_error(self, hass: HomeAssistant) -> None:
+        entry = _existing_entry(hass)
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_MAC: "not-a-mac", CONF_NAME: TEST_NAME},
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"] == {CONF_MAC: "invalid_mac"}
+
+    async def test_reconfigure_unreachable_shows_error(self, hass: HomeAssistant) -> None:
+        entry = _existing_entry(hass)
+        result = await entry.start_reconfigure_flow(hass)
+        with patch(_VALIDATE, AsyncMock(return_value=False)):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_MAC: OTHER_MAC, CONF_NAME: TEST_NAME},
+            )
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"] == {"base": "cannot_connect"}
+
+    async def test_reconfigure_collision_aborts(self, hass: HomeAssistant) -> None:
+        entry = _existing_entry(hass)
+        other = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id=OTHER_MAC,
+            data={CONF_MAC: OTHER_MAC, CONF_NAME: "Other Fan", CONF_SPEED_COUNT: 3},
+        )
+        other.add_to_hass(hass)
+
+        result = await entry.start_reconfigure_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_MAC: OTHER_MAC, CONF_NAME: TEST_NAME},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "already_configured"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,7 +7,7 @@ logic. They run on all platforms (no HA test harness required).
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -208,3 +208,59 @@ class TestPersistentNotification:
         await coordinator._async_update_data()
 
         mock_hass.services.async_call.assert_not_called()
+
+
+class TestLogWhenUnavailable:
+    """Silver `log-when-unavailable`: warn once on loss, log once on recovery.
+
+    The old code warned on every failed poll, so a fan that was unreachable for
+    a day produced ~288 identical warnings. These tests pin the once-each
+    behaviour and the hand-off to HA's own logging on hard escalation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_warns_once_across_many_soft_failures(self) -> None:
+        coordinator, mock_device, _ = _make_coordinator(unavailable_threshold=0)
+        coordinator.data = FanimationState(speed=1)
+        mock_device.async_get_status.side_effect = Exception("BLE timeout")
+
+        with patch("custom_components.fanimation.coordinator.LOGGER") as logger:
+            for _ in range(5):
+                await coordinator._async_update_data()
+
+        # One warning despite five failed polls; the rest drop to debug.
+        assert logger.warning.call_count == 1
+        assert coordinator._unavailable_logged is True
+
+    @pytest.mark.asyncio
+    async def test_logs_recovery_once(self) -> None:
+        coordinator, mock_device, _ = _make_coordinator(unavailable_threshold=0)
+        coordinator.data = FanimationState(speed=1)
+        mock_device.async_get_status.side_effect = Exception("BLE timeout")
+        for _ in range(3):
+            await coordinator._async_update_data()
+
+        mock_device.async_get_status.side_effect = None
+        mock_device.async_get_status.return_value = FanimationState(speed=2)
+        with patch("custom_components.fanimation.coordinator.LOGGER") as logger:
+            await coordinator._async_update_data()
+
+        logger.info.assert_called_once()
+        assert coordinator._unavailable_logged is False
+
+    @pytest.mark.asyncio
+    async def test_hard_escalation_hands_off_logging(self) -> None:
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        coordinator, mock_device, _ = _make_coordinator(unavailable_threshold=2)
+        coordinator.data = FanimationState(speed=1)
+        mock_device.async_get_status.side_effect = Exception("BLE timeout")
+
+        await coordinator._async_update_data()  # soft failure 1 → warned
+        assert coordinator._unavailable_logged is True
+
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()  # failure 2 = threshold → hard
+
+        # Flag reset so HA's coordinator owns subsequent loss/recovery logging.
+        assert coordinator._unavailable_logged is False

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,6 +7,7 @@ logic. They run on all platforms (no HA test harness required).
 
 from __future__ import annotations
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -16,6 +17,9 @@ from custom_components.fanimation.const import (
     CONF_UNAVAILABLE_THRESHOLD,
     DEFAULT_NOTIFY_ON_DISCONNECT,
     DEFAULT_UNAVAILABLE_THRESHOLD,
+    POLL_FAST,
+    POLL_FAST_CYCLES,
+    POLL_SLOW,
 )
 from custom_components.fanimation.device import FanimationState
 
@@ -264,3 +268,86 @@ class TestLogWhenUnavailable:
 
         # Flag reset so HA's coordinator owns subsequent loss/recovery logging.
         assert coordinator._unavailable_logged is False
+
+
+class TestFastPoll:
+    """Cover the fast/slow poll transition and async_start_fast_poll."""
+
+    @pytest.mark.asyncio
+    async def test_start_fast_poll_sets_interval_and_refreshes(self) -> None:
+        coordinator, _, _ = _make_coordinator()
+        # Stub HA's refresh scheduler — we only assert our own bookkeeping.
+        coordinator.async_request_refresh = AsyncMock()
+
+        await coordinator.async_start_fast_poll()
+
+        assert coordinator._fast_poll_remaining == POLL_FAST_CYCLES
+        assert coordinator.update_interval == timedelta(seconds=POLL_FAST)
+        coordinator.async_request_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fast_poll_decrements_and_reverts_to_slow(self) -> None:
+        coordinator, mock_device, _ = _make_coordinator()
+        mock_device.async_get_status.return_value = FanimationState(speed=1)
+        coordinator._fast_poll_remaining = 1
+        coordinator.update_interval = timedelta(seconds=POLL_FAST)
+
+        await coordinator._async_update_data()
+
+        assert coordinator._fast_poll_remaining == 0
+        assert coordinator.update_interval == timedelta(seconds=POLL_SLOW)
+
+    @pytest.mark.asyncio
+    async def test_fast_poll_stays_fast_until_cycles_exhausted(self) -> None:
+        coordinator, mock_device, _ = _make_coordinator()
+        mock_device.async_get_status.return_value = FanimationState(speed=1)
+        coordinator._fast_poll_remaining = 2
+        coordinator.update_interval = timedelta(seconds=POLL_FAST)
+
+        await coordinator._async_update_data()
+
+        assert coordinator._fast_poll_remaining == 1
+        assert coordinator.update_interval == timedelta(seconds=POLL_FAST)
+
+
+class TestGetOptionFallback:
+    """Cover the _get_option default branch when no options are set."""
+
+    def test_returns_default_without_options(self) -> None:
+        coordinator, _, _ = _make_coordinator()
+        coordinator.config_entry.options = {}  # falsy → fall through to default
+        assert coordinator._get_option("missing", "fallback") == "fallback"
+
+
+class TestNotificationEdgeCases:
+    """Cover the notification early-returns and error-swallowing paths."""
+
+    @pytest.mark.asyncio
+    async def test_create_noop_when_already_active(self) -> None:
+        coordinator, _, mock_hass = _make_coordinator()
+        coordinator._notification_active = True
+        await coordinator._async_create_notification()
+        mock_hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_swallows_service_error(self) -> None:
+        coordinator, _, mock_hass = _make_coordinator()
+        mock_hass.services.async_call.side_effect = Exception("HA service down")
+        # Must not raise even though the persistent-notification call fails.
+        await coordinator._async_create_notification()
+        assert coordinator._notification_active is True
+
+    @pytest.mark.asyncio
+    async def test_dismiss_noop_when_not_active(self) -> None:
+        coordinator, _, mock_hass = _make_coordinator()
+        assert coordinator._notification_active is False
+        await coordinator._async_dismiss_notification()
+        mock_hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dismiss_swallows_service_error(self) -> None:
+        coordinator, _, mock_hass = _make_coordinator()
+        coordinator._notification_active = True
+        mock_hass.services.async_call.side_effect = Exception("HA service down")
+        await coordinator._async_dismiss_notification()
+        assert coordinator._notification_active is False

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -7,6 +7,10 @@ dependency, no mocking of bleak, and no Home Assistant test harness.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
 from custom_components.fanimation.const import (
     CMD_GET_STATUS,
     CMD_SET_STATE,
@@ -15,7 +19,7 @@ from custom_components.fanimation.const import (
 )
 from custom_components.fanimation.device import FanimationDevice, FanimationState
 
-from .conftest import build_response
+from .conftest import TEST_MAC, TEST_NAME, build_response
 
 # ---------------------------------------------------------------------------
 # _build_packet tests
@@ -271,3 +275,192 @@ class TestFanimationState:
         s1 = FanimationState(speed=1)
         s2 = FanimationState(speed=2)
         assert s1 != s2
+
+
+# ---------------------------------------------------------------------------
+# Stateful BLE client tests
+#
+# These inject an AsyncMock/MagicMock client and patch the conftest-stubbed
+# ``bluetooth`` / ``establish_connection`` in the device namespace — no real
+# Bluetooth, no hardware.
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceBasics:
+    """Construction, properties, notification handler, disconnect callback."""
+
+    def test_init_and_properties(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        assert device.mac == TEST_MAC
+        assert device.name == TEST_NAME
+        assert device._client is None
+
+    def test_notification_handler_stores_and_signals(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        data = build_response(speed=1)
+        device._notification_handler(None, data)
+        assert device._last_notification == data
+        assert device._notify_event.is_set()
+
+    def test_on_disconnect_clears_client(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        device._client = MagicMock()
+        device._on_disconnect(MagicMock())
+        assert device._client is None
+
+
+_ADDR = "custom_components.fanimation.device.bluetooth.async_ble_device_from_address"
+_CONNECT = "custom_components.fanimation.device.establish_connection"
+
+
+class TestEnsureConnected:
+    @pytest.mark.asyncio
+    async def test_noop_when_already_connected(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        client = MagicMock()
+        client.is_connected = True
+        device._client = client
+        await device._ensure_connected()
+        assert device._client is client
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_adapter_finds_device(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        with patch(_ADDR, return_value=None), pytest.raises(ConnectionError):
+            await device._ensure_connected()
+
+    @pytest.mark.asyncio
+    async def test_connects_and_subscribes(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        client = AsyncMock()
+        with (
+            patch(_ADDR, return_value=MagicMock()),
+            patch(_CONNECT, AsyncMock(return_value=client)),
+        ):
+            await device._ensure_connected()
+        assert device._client is client
+        client.start_notify.assert_awaited_once()
+
+
+class TestDisconnect:
+    @pytest.mark.asyncio
+    async def test_closes_and_clears(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        client = AsyncMock()
+        device._client = client
+        await device.disconnect()
+        client.disconnect.assert_awaited_once()
+        assert device._client is None
+
+    @pytest.mark.asyncio
+    async def test_noop_without_client(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        await device.disconnect()
+        assert device._client is None
+
+    @pytest.mark.asyncio
+    async def test_swallows_disconnect_errors(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        client = AsyncMock()
+        client.disconnect.side_effect = Exception("BLE error")
+        device._client = client
+        await device.disconnect()
+        assert device._client is None
+
+
+class TestSendAndReceive:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_notification(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        response = build_response(speed=2)
+
+        async def _write(_char: object, _packet: object) -> None:
+            device._notification_handler(None, response)
+
+        client = AsyncMock()
+        client.write_gatt_char = AsyncMock(side_effect=_write)
+        device._client = client
+
+        result = await device._send_and_receive(FanimationDevice._build_packet(CMD_GET_STATUS))
+        assert result == response
+
+    @pytest.mark.asyncio
+    async def test_malformed_packet_raises(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        device._client = AsyncMock()
+        with pytest.raises(ValueError):
+            await device._send_and_receive(b"\x00\x01")
+
+    @pytest.mark.asyncio
+    async def test_raises_when_not_connected(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        device._client = None
+        with pytest.raises(ConnectionError):
+            await device._send_and_receive(FanimationDevice._build_packet(CMD_GET_STATUS))
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_none(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        device._client = AsyncMock()  # write does nothing → no notification
+        result = await device._send_and_receive(
+            FanimationDevice._build_packet(CMD_GET_STATUS), timeout=0.01
+        )
+        assert result is None
+
+
+class TestAsyncGetStatus:
+    @pytest.mark.asyncio
+    async def test_returns_parsed_state(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        device._ensure_connected = AsyncMock()
+        device._send_and_receive = AsyncMock(return_value=build_response(speed=2, downlight=40))
+        state = await device.async_get_status()
+        assert state is not None
+        assert state.speed == 2
+        assert state.downlight == 40
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_no_response(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        device._ensure_connected = AsyncMock()
+        device._send_and_receive = AsyncMock(return_value=None)
+        assert await device.async_get_status() is None
+
+
+class TestAsyncSetState:
+    @pytest.mark.asyncio
+    async def test_merges_unset_fields_and_verifies(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        device._ensure_connected = AsyncMock()
+        current = build_response(speed=1, downlight=50)
+        verify = build_response(speed=3, downlight=50)
+        # GET (read-before-write), SET (echo, ignored), GET (verify)
+        device._send_and_receive = AsyncMock(side_effect=[current, build_response(speed=3), verify])
+        state = await device.async_set_state(speed=3)
+        assert state is not None
+        assert state.speed == 3
+        assert state.downlight == 50  # preserved from current state
+
+    @pytest.mark.asyncio
+    async def test_none_when_initial_read_fails(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        device._ensure_connected = AsyncMock()
+        device._send_and_receive = AsyncMock(return_value=None)
+        assert await device.async_set_state(speed=3) is None
+
+    @pytest.mark.asyncio
+    async def test_none_when_read_unparseable(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        device._ensure_connected = AsyncMock()
+        bad = build_response(speed=1)
+        bad[9] = 0  # corrupt checksum → parse returns None
+        device._send_and_receive = AsyncMock(return_value=bad)
+        assert await device.async_set_state(speed=3) is None
+
+    @pytest.mark.asyncio
+    async def test_none_when_verify_fails(self) -> None:
+        device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
+        device._ensure_connected = AsyncMock()
+        current = build_response(speed=1, downlight=50)
+        device._send_and_receive = AsyncMock(side_effect=[current, build_response(speed=3), None])
+        assert await device.async_set_state(speed=3) is None

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -402,9 +402,7 @@ class TestSendAndReceive:
     async def test_timeout_returns_none(self) -> None:
         device = FanimationDevice(MagicMock(), TEST_MAC, TEST_NAME)
         device._client = AsyncMock()  # write does nothing → no notification
-        result = await device._send_and_receive(
-            FanimationDevice._build_packet(CMD_GET_STATUS), timeout=0.01
-        )
+        result = await device._send_and_receive(FanimationDevice._build_packet(CMD_GET_STATUS), timeout=0.01)
         assert result is None
 
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,71 @@
+"""Tests for the Fanimation BLE diagnostics dump.
+
+Diagnostics imports ``homeassistant.components.diagnostics``, so this module
+needs Home Assistant available and runs on Linux CI only (the maintainer's
+pure-logic suites run on Windows; this one is skipped there).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+# Skip on Windows — pulls in the HA diagnostics component.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Diagnostics requires Home Assistant (Linux CI only)",
+)
+
+from unittest.mock import MagicMock
+
+from homeassistant.const import CONF_MAC, CONF_NAME
+
+from custom_components.fanimation.const import CONF_SPEED_COUNT
+from custom_components.fanimation.device import FanimationState
+
+from .conftest import TEST_MAC, TEST_NAME
+
+
+def _make_entry(state: FanimationState | None, *, failures: int = 0):
+    """Build a config entry whose runtime_data is a mocked coordinator."""
+    coordinator = MagicMock()
+    coordinator.data = state
+    coordinator.last_update_success = state is not None
+    coordinator.update_interval = None
+    coordinator.connection_failures = failures
+
+    entry = MagicMock()
+    entry.title = TEST_NAME
+    entry.runtime_data = coordinator
+    entry.data = {CONF_MAC: TEST_MAC, CONF_NAME: TEST_NAME, CONF_SPEED_COUNT: 3}
+    entry.options = {}
+    return entry
+
+
+async def test_diagnostics_redacts_mac_and_includes_state() -> None:
+    from custom_components.fanimation.diagnostics import async_get_config_entry_diagnostics
+
+    entry = _make_entry(FanimationState(speed=2, direction=1, downlight=50, timer_minutes=30, fan_type=7))
+
+    result = await async_get_config_entry_diagnostics(MagicMock(), entry)
+
+    # MAC redacted, other fields preserved.
+    assert result["entry"]["data"][CONF_MAC] == "**REDACTED**"
+    assert result["entry"]["data"][CONF_NAME] == TEST_NAME
+    assert result["entry"]["data"][CONF_SPEED_COUNT] == 3
+    # Protocol state surfaced verbatim (direction/fan_type are the #4 debug keys).
+    assert result["state"]["direction"] == 1
+    assert result["state"]["fan_type"] == 7
+    assert result["coordinator"]["connection_failures"] == 0
+
+
+async def test_diagnostics_handles_no_state() -> None:
+    from custom_components.fanimation.diagnostics import async_get_config_entry_diagnostics
+
+    entry = _make_entry(None, failures=3)
+
+    result = await async_get_config_entry_diagnostics(MagicMock(), entry)
+
+    assert result["state"] is None
+    assert result["coordinator"]["connection_failures"] == 3

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -9,7 +9,7 @@ Pure unit tests — no HA test harness required. Cover:
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.components.fan import DIRECTION_FORWARD, DIRECTION_REVERSE, FanEntityFeature
@@ -387,3 +387,94 @@ class TestFanMisc:
         attrs = fan.extra_state_attributes
         assert "rf_remote_sync" in attrs
         assert attrs["connection_status"] == "connected"
+
+
+class TestSpeedCountRepairIssue:
+    """repair-issues (Gold): raise a repair when the fan reports speed > speed_count.
+
+    Issue #1 follow-up: the ``percentage`` clamp keeps the slider usable when a
+    fan reports a hardware speed above the configured count (e.g. a 32-speed DC
+    fan left at the default 3). This rule surfaces *why* it's pegged and how to
+    fix it — a user-actionable misconfiguration, resolved in the options flow.
+    """
+
+    @staticmethod
+    def _ready_fan(speed_count: int = 3, speed: int = 0):
+        """A fan that has been 'added to hass': coordinator data + a hass handle."""
+        fan, coord = _make_fan(speed_count=speed_count)
+        fan.hass = MagicMock()
+        coord.data = FanimationState(speed=speed)
+        return fan, coord
+
+    def test_issue_raised_when_speed_exceeds_count(self) -> None:
+        fan, _ = self._ready_fan(speed_count=3, speed=5)
+        with (
+            patch("custom_components.fanimation.fan.ir.async_create_issue") as create,
+            patch("custom_components.fanimation.fan.ir.async_delete_issue") as delete,
+        ):
+            fan._evaluate_speed_count_issue()
+
+        delete.assert_not_called()
+        create.assert_called_once()
+        args, kwargs = create.call_args
+        assert args[1] == "fanimation"  # DOMAIN
+        assert args[2] == "speed_count_out_of_range_test_entry"  # issue_id keyed on entry
+        assert kwargs["is_fixable"] is False
+        assert kwargs["severity"].name == "WARNING"
+        assert kwargs["translation_key"] == "speed_count_out_of_range"
+        assert kwargs["translation_placeholders"] == {
+            "name": "Test Fan",
+            "reported_speed": "5",
+            "speed_count": "3",
+        }
+
+    @pytest.mark.parametrize("speed", [0, 1, 2, 3])
+    def test_issue_cleared_when_speed_in_range(self, speed: int) -> None:
+        """In-range (incl. off and the boundary speed==count) clears any open issue."""
+        fan, _ = self._ready_fan(speed_count=3, speed=speed)
+        with (
+            patch("custom_components.fanimation.fan.ir.async_create_issue") as create,
+            patch("custom_components.fanimation.fan.ir.async_delete_issue") as delete,
+        ):
+            fan._evaluate_speed_count_issue()
+
+        create.assert_not_called()
+        delete.assert_called_once_with(fan.hass, "fanimation", "speed_count_out_of_range_test_entry")
+
+    def test_no_issue_created_without_data(self) -> None:
+        """No coordinator data yet (never polled) must not raise a false issue."""
+        fan, coord = self._ready_fan(speed_count=3)
+        coord.data = None
+        with (
+            patch("custom_components.fanimation.fan.ir.async_create_issue") as create,
+            patch("custom_components.fanimation.fan.ir.async_delete_issue") as delete,
+        ):
+            fan._evaluate_speed_count_issue()
+
+        create.assert_not_called()
+        delete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_added_to_hass_evaluates_immediately(self) -> None:
+        """An already-out-of-range state at setup raises without waiting for a poll."""
+        fan, _ = self._ready_fan(speed_count=3, speed=5)
+        with patch("custom_components.fanimation.fan.ir.async_create_issue") as create:
+            await fan.async_added_to_hass()
+        create.assert_called_once()
+
+    def test_coordinator_update_evaluates_and_writes_state(self) -> None:
+        """The poll hook evaluates the issue and still writes entity state."""
+        fan, _ = self._ready_fan(speed_count=3, speed=5)
+        fan.async_write_ha_state = MagicMock()
+        with patch("custom_components.fanimation.fan.ir.async_create_issue") as create:
+            fan._handle_coordinator_update()
+        create.assert_called_once()
+        fan.async_write_ha_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_removal_clears_issue(self) -> None:
+        """Removing the entity (e.g. integration deletion) clears a lingering issue."""
+        fan, _ = self._ready_fan(speed_count=3, speed=5)
+        with patch("custom_components.fanimation.fan.ir.async_delete_issue") as delete:
+            await fan.async_will_remove_from_hass()
+        delete.assert_called_once_with(fan.hass, "fanimation", "speed_count_out_of_range_test_entry")

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -340,3 +340,50 @@ class TestIssue4Direction:
         fan, coord = _make_fan(fan_type=2)
         await fan.async_set_direction(DIRECTION_FORWARD)
         coord.device.async_set_state.assert_called_once_with(direction=DIR_FORWARD)
+
+
+class TestFanMisc:
+    """Cover setup, is_on, percentage-without-data, and extra attributes."""
+
+    @pytest.mark.asyncio
+    async def test_async_setup_entry_adds_one_fan(self) -> None:
+        from custom_components.fanimation.fan import FanimationFan, async_setup_entry
+
+        _, coordinator = _make_fan()
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        entry.entry_id = "test_entry"
+        entry.options = {}
+        entry.data = {CONF_SPEED_COUNT: 3}
+
+        added: list = []
+        await async_setup_entry(MagicMock(), entry, lambda e: added.extend(e))
+
+        assert len(added) == 1
+        assert isinstance(added[0], FanimationFan)
+
+    def test_is_on_true_when_running(self) -> None:
+        fan, coord = _make_fan()
+        coord.data = FanimationState(speed=2)
+        assert fan.is_on is True
+
+    def test_is_on_false_when_off(self) -> None:
+        fan, coord = _make_fan()
+        coord.data = FanimationState(speed=0)
+        assert fan.is_on is False
+
+    def test_is_on_none_without_data(self) -> None:
+        fan, coord = _make_fan()
+        coord.data = None
+        assert fan.is_on is None
+
+    def test_percentage_none_without_data(self) -> None:
+        fan, coord = _make_fan()
+        coord.data = None
+        assert fan.percentage is None
+
+    def test_extra_state_attributes(self) -> None:
+        fan, _ = _make_fan()
+        attrs = fan.extra_state_attributes
+        assert "rf_remote_sync" in attrs
+        assert attrs["connection_status"] == "connected"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,99 @@
+"""Tests for the integration setup/unload entry points (__init__.py).
+
+Pure unit tests: HA's config-entry machinery is mocked and the coordinator's
+first refresh is patched, so ``async_setup_entry`` exercises only its own
+orchestration — no real BLE, no HA refresh scheduler.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.const import CONF_MAC, CONF_NAME
+
+from custom_components.fanimation import (
+    _async_options_updated,
+    async_setup_entry,
+    async_unload_entry,
+)
+from custom_components.fanimation.const import PLATFORMS
+from custom_components.fanimation.coordinator import FanimationCoordinator
+
+from .conftest import TEST_MAC, TEST_NAME
+
+
+def _make_entry():
+    """Build a config entry shaped like a real one for setup/unload."""
+    entry = MagicMock()
+    entry.data = {CONF_MAC: TEST_MAC, CONF_NAME: TEST_NAME}
+    entry.entry_id = "test_entry"
+    entry.title = TEST_NAME
+    return entry
+
+
+class TestSetupEntry:
+    @pytest.mark.asyncio
+    async def test_setup_creates_coordinator_and_forwards_platforms(self) -> None:
+        hass = MagicMock()
+        hass.config_entries.async_forward_entry_setups = AsyncMock()
+        entry = _make_entry()
+
+        with patch.object(
+            FanimationCoordinator, "async_config_entry_first_refresh", new_callable=AsyncMock
+        ) as mock_first_refresh:
+            result = await async_setup_entry(hass, entry)
+
+        assert result is True
+        # Real coordinator constructed and stored on the entry for platform access.
+        assert isinstance(entry.runtime_data, FanimationCoordinator)
+        mock_first_refresh.assert_awaited_once()
+        # Our options-update listener is registered (reload-on-change) and its
+        # unsub wired for cleanup. Note async_on_unload is also called by HA's
+        # DataUpdateCoordinator for its own async_shutdown, so assert our call
+        # specifically rather than the total count.
+        entry.add_update_listener.assert_called_once_with(_async_options_updated)
+        entry.async_on_unload.assert_any_call(entry.add_update_listener.return_value)
+        # Platforms forwarded exactly once with the integration's PLATFORMS.
+        hass.config_entries.async_forward_entry_setups.assert_awaited_once_with(entry, PLATFORMS)
+
+
+class TestOptionsUpdated:
+    @pytest.mark.asyncio
+    async def test_options_update_triggers_reload(self) -> None:
+        hass = MagicMock()
+        hass.config_entries.async_reload = AsyncMock()
+        entry = _make_entry()
+
+        await _async_options_updated(hass, entry)
+
+        hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+
+
+class TestUnloadEntry:
+    @pytest.mark.asyncio
+    async def test_unload_success_disconnects_device(self) -> None:
+        hass = MagicMock()
+        hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+        entry = _make_entry()
+        entry.runtime_data = MagicMock()
+        entry.runtime_data.device.disconnect = AsyncMock()
+
+        result = await async_unload_entry(hass, entry)
+
+        assert result is True
+        hass.config_entries.async_unload_platforms.assert_awaited_once_with(entry, PLATFORMS)
+        entry.runtime_data.device.disconnect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unload_failure_skips_disconnect(self) -> None:
+        hass = MagicMock()
+        hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
+        entry = _make_entry()
+        entry.runtime_data = MagicMock()
+        entry.runtime_data.device.disconnect = AsyncMock()
+
+        result = await async_unload_entry(hass, entry)
+
+        assert result is False
+        entry.runtime_data.device.disconnect.assert_not_awaited()

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -90,3 +90,58 @@ class TestDefaultBrightness:
         await light.async_turn_on()
 
         mock_coord.device.async_set_state.assert_called_once_with(downlight=100)
+
+
+class TestLightMisc:
+    """Cover setup, is_on, brightness, extra attributes, and turn_off."""
+
+    @pytest.mark.asyncio
+    async def test_async_setup_entry_adds_one_light(self) -> None:
+        from custom_components.fanimation.light import FanimationLight, async_setup_entry
+
+        _, coordinator = _make_light()
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        entry.entry_id = "test_entry"
+
+        added: list = []
+        await async_setup_entry(MagicMock(), entry, lambda e: added.extend(e))
+
+        assert len(added) == 1
+        assert isinstance(added[0], FanimationLight)
+
+    def test_is_on_true_when_lit(self) -> None:
+        light, coord = _make_light()
+        coord.data = FanimationState(downlight=50)
+        assert light.is_on is True
+
+    def test_is_on_false_when_dark(self) -> None:
+        light, coord = _make_light()
+        coord.data = FanimationState(downlight=0)
+        assert light.is_on is False
+
+    def test_is_on_none_without_data(self) -> None:
+        light, coord = _make_light()
+        coord.data = None
+        assert light.is_on is None
+
+    def test_brightness_scales_to_ha_255(self) -> None:
+        light, coord = _make_light()
+        coord.data = FanimationState(downlight=DOWNLIGHT_MAX)
+        assert light.brightness == 255
+
+    def test_brightness_none_without_data(self) -> None:
+        light, coord = _make_light()
+        coord.data = None
+        assert light.brightness is None
+
+    def test_extra_state_attributes(self) -> None:
+        light, _ = _make_light()
+        assert "rf_remote_sync" in light.extra_state_attributes
+
+    @pytest.mark.asyncio
+    async def test_turn_off_sets_downlight_zero(self) -> None:
+        light, coord = _make_light()
+        await light.async_turn_off()
+        coord.device.async_set_state.assert_called_once_with(downlight=0)
+        coord.async_start_fast_poll.assert_awaited_once()

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,119 @@
+"""Tests for the Fanimation sleep-timer (number) entity.
+
+Pure unit tests — no HA harness required (mirrors test_light.py). Covers the native
+value, the fan-must-be-running guard (the translatable HomeAssistantError), the
+cancel / no-state edge cases, the extra-state attributes, and platform setup.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.fanimation.const import DOMAIN
+from custom_components.fanimation.device import FanimationState
+
+
+def _make_coordinator(speed: int = 1, timer_minutes: int = 0):
+    """Build a mocked coordinator shaped like the real one (see test_light.py)."""
+    coordinator = MagicMock()
+    coordinator.device = MagicMock()
+    coordinator.device.mac = "AA:BB:CC:DD:EE:FF"
+    coordinator.device.name = "Test Fan"
+    coordinator.device.async_set_state = AsyncMock()
+    coordinator.async_start_fast_poll = AsyncMock()
+    coordinator.data = FanimationState(speed=speed, timer_minutes=timer_minutes)
+    coordinator.connection_failures = 0
+    return coordinator
+
+
+def _make_timer(speed: int = 1, timer_minutes: int = 0):
+    """Create a FanimationTimer backed by a mocked coordinator."""
+    from custom_components.fanimation.number import FanimationTimer
+
+    coordinator = _make_coordinator(speed=speed, timer_minutes=timer_minutes)
+    return FanimationTimer(coordinator, "test_entry"), coordinator
+
+
+def test_unique_id_and_native_value() -> None:
+    timer, _ = _make_timer(timer_minutes=120)
+    assert timer._attr_unique_id == "AA:BB:CC:DD:EE:FF_timer"
+    assert timer.native_value == 120
+
+
+def test_native_value_is_none_without_data() -> None:
+    timer, coordinator = _make_timer()
+    coordinator.data = None
+    assert timer.native_value is None
+
+
+@pytest.mark.asyncio
+async def test_set_timer_while_running_sends_command() -> None:
+    timer, coordinator = _make_timer(speed=1)
+
+    await timer.async_set_native_value(30)
+
+    coordinator.device.async_set_state.assert_called_once_with(timer_minutes=30)
+    coordinator.async_start_fast_poll.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_set_timer_while_fan_off_raises_translatable() -> None:
+    timer, coordinator = _make_timer(speed=0)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await timer.async_set_native_value(30)
+
+    # The rule under test: a translation_key, not a hard-coded English message.
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "timer_requires_fan_on"
+    coordinator.device.async_set_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cancel_timer_allowed_while_fan_off() -> None:
+    # Setting 0 cancels the timer and must be allowed even with the fan stopped.
+    timer, coordinator = _make_timer(speed=0)
+
+    await timer.async_set_native_value(0)
+
+    coordinator.device.async_set_state.assert_called_once_with(timer_minutes=0)
+
+
+@pytest.mark.asyncio
+async def test_set_timer_without_state_does_not_raise() -> None:
+    # No coordinator data yet → the running-check is skipped and the command is sent.
+    timer, coordinator = _make_timer(speed=0)
+    coordinator.data = None
+
+    await timer.async_set_native_value(30)
+
+    coordinator.device.async_set_state.assert_called_once_with(timer_minutes=30)
+
+
+def test_extra_state_attributes_extend_base() -> None:
+    timer, _ = _make_timer()
+
+    attrs = timer.extra_state_attributes
+
+    assert attrs["connection_status"] == "connected"  # inherited from FanimationEntity
+    assert "Fan must be running" in attrs["timer_note"]
+    assert "rf_remote_sync" in attrs
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_adds_single_timer() -> None:
+    from custom_components.fanimation.number import FanimationTimer, async_setup_entry
+
+    coordinator = _make_coordinator()
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+    entry.entry_id = "test_entry"
+
+    added: list = []
+    await async_setup_entry(MagicMock(), entry, lambda entities: added.extend(entities))
+
+    assert len(added) == 1
+    assert isinstance(added[0], FanimationTimer)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from homeassistant.exceptions import HomeAssistantError
 
-from custom_components.fanimation.const import DOMAIN
+from custom_components.fanimation.const import DOMAIN, POLL_SLOW
 from custom_components.fanimation.device import FanimationState
 
 
@@ -117,3 +117,35 @@ async def test_async_setup_entry_adds_single_timer() -> None:
 
     assert len(added) == 1
     assert isinstance(added[0], FanimationTimer)
+
+
+class TestConnectionStatus:
+    """Cover the base entity's connection_status formatting (entity.py)."""
+
+    def test_connected_when_no_failures(self) -> None:
+        timer, coordinator = _make_timer()
+        coordinator.connection_failures = 0
+        assert timer.extra_state_attributes["connection_status"] == "connected"
+
+    def test_single_failure_is_singular(self) -> None:
+        timer, coordinator = _make_timer()
+        coordinator.connection_failures = 1
+        status = timer.extra_state_attributes["connection_status"]
+        assert status == f"unreachable (1 attempt, ~{POLL_SLOW // 60} min)"
+
+    def test_minutes_window_is_plural(self) -> None:
+        timer, coordinator = _make_timer()
+        coordinator.connection_failures = 2
+        status = timer.extra_state_attributes["connection_status"]
+        assert "2 attempts" in status
+        assert "min" in status
+
+    def test_hours_window(self) -> None:
+        timer, coordinator = _make_timer()
+        coordinator.connection_failures = 3600 // POLL_SLOW  # 60 min → "~1 hr"
+        assert "hr" in timer.extra_state_attributes["connection_status"]
+
+    def test_days_window(self) -> None:
+        timer, coordinator = _make_timer()
+        coordinator.connection_failures = 86400 // POLL_SLOW  # 1440 min → "~1 day(s)"
+        assert "day(s)" in timer.extra_state_attributes["connection_status"]

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -93,3 +93,31 @@ def test_config_flow_error_and_abort_keys_are_translated() -> None:
         missing_aborts = abort_keys - set(config.get("abort", {}))
         assert not missing_errors, f"{name}: config.error is missing {sorted(missing_errors)}"
         assert not missing_aborts, f"{name}: config.abort is missing {sorted(missing_aborts)}"
+
+
+def _raised_translation_keys() -> set[str]:
+    """Collect ``translation_key`` values from ``raise <Error>(..., translation_key="x")``.
+
+    Walks every module in the component so any HomeAssistantError raised with a
+    ``translation_key`` is covered, not just today's sleep-timer one. A key present
+    here but absent from ``exceptions`` in the JSON renders as a raw key in the UI.
+    """
+    keys: set[str] = set()
+    for path in sorted(_COMPONENT.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call):
+                for keyword in node.exc.keywords:
+                    if keyword.arg == "translation_key" and isinstance(keyword.value, ast.Constant):
+                        keys.add(keyword.value.value)
+    return keys
+
+
+def test_raised_exception_keys_are_translated() -> None:
+    """Every ``raise ...(translation_key=...)`` key exists under ``exceptions`` in both files."""
+    keys = _raised_translation_keys()
+    assert keys, "expected at least one raise(..., translation_key=...) in the component"
+
+    for name, data in (("strings.json", _load(_STRINGS)), ("translations/en.json", _load(_TRANSLATIONS))):
+        missing = keys - set(data.get("exceptions", {}))
+        assert not missing, f"{name}: exceptions is missing {sorted(missing)}"


### PR DESCRIPTION
## What this is

Draft PR to run CI against the `chore/platinum-foundation` work. Feature-branch pushes don't trigger the Tests/Lint/Validate/mypy workflows (they only run on push/PR to `main`), so this PR is the first real execution of several pieces.

## Quality-scale rules this verifies

- **reconfiguration-flow (Gold)** — `async_step_reconfigure` (change a fan entry's MAC/name in place) + 6 `TestReconfigure` cases. These config-flow tests are Linux/CI-only (skipped on the Windows dev box), so the **Tests** workflow is their first actual run.
- **strict-typing (Platinum)** — new **mypy `--strict`** CI job (`.github/workflows/mypy.yml`) running `mypy custom_components/fanimation`. Passes locally (0 issues, 10 files); the CI job is what the rule needs to be marked `done`.

## Also included

- **test-coverage Phase 1** — `entity.py` / `fan.py` / `light.py` / `device.py` to 100% locally (characterization tests; no production code changed).
- `docs/quality_scale.yaml` tracker comment refreshed; one ruff-format fix.

## Review / test plan

- [x] **Tests** green (incl. the 6 reconfigure cases)
- [x] **mypy --strict** green
- [x] **Lint** (ruff check + format) green
- [x] **Validate** (hassfest + HACS) green

Draft on purpose — once CI is green and reviewed, flip `reconfiguration-flow` and `strict-typing` to `done` in `docs/quality_scale.yaml`, then merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)